### PR TITLE
27 refactor class definitions in removedialoguewindowpy module to separate modules

### DIFF
--- a/desktopApp/Jahtirekisteri.py
+++ b/desktopApp/Jahtirekisteri.py
@@ -15,7 +15,12 @@ import pgModule
 import prepareData
 import dialogs.dialogueWindow as dialogueWindow
 import dialogs.addDialogueWindow as addDialogueWindow
-import dialogs.removeDialogueWindow as removeDialogueWindow
+
+# imports _remove_ Dialogue Window modules
+import dialogs.removeDialogues.Group as removeDialogueWindowGroup
+import dialogs.removeDialogues.Member as removeDialogueWindowMember
+import dialogs.removeDialogues.Party as removeDialogueWindowParty
+
 import dialogs.editDialogueWindow as editDialogueWindow
 import dialogs.editShotDialog as editShotDialog
 import figures
@@ -969,7 +974,7 @@ class MultiPageMainWindow(QMainWindow):
         dialog.exec()
     
     def openRemoveMemberDialog(self):
-        dialog = removeDialogueWindow.Member()
+        dialog = removeDialogueWindowMember.Member()
         dialog.exec()
     
     def openAddMembershipDialog(self):
@@ -981,7 +986,7 @@ class MultiPageMainWindow(QMainWindow):
         dialog.exec()
 
     def openRemoveGroupDialog(self):
-        dialog = removeDialogueWindow.Group()
+        dialog = removeDialogueWindowGroup.Group()
         dialog.exec()
 
     def openAddMPartyDialog(self):
@@ -989,7 +994,7 @@ class MultiPageMainWindow(QMainWindow):
         dialog.exec()
     
     def openRemovePartyDialog(self):
-        dialog = removeDialogueWindow.Party()
+        dialog = removeDialogueWindowParty.Party()
         dialog.exec()
     
     def openEditCompanyDialog(self):

--- a/desktopApp/dialogs/removeDialogues/Group.py
+++ b/desktopApp/dialogs/removeDialogues/Group.py
@@ -1,0 +1,93 @@
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import QDialog, QComboBox, QLabel, QPushButton
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame, SuccessfulOperationDialog
+import pgModule as pgModule
+import prepareData as prepareData
+from datetime import date
+
+class Group(DialogFrame):
+    """Creates a dialog to remove group from database"""
+    
+    # Constructor
+    def __init__(self):
+
+        super().__init__()
+
+        loadUi("ui/removeGroupDialog.ui", self)
+
+        self.setWindowTitle('Poista ryhmä')
+
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+
+        # Elements
+        self.removeGroupCB = self.removeGroupComboBox
+        
+        
+        self.removeGroupRemovePushBtn = self.removeGroupRemovePushButton
+        self.removeGroupRemovePushBtn.clicked.connect(self.removeGroup) # Signal
+        self.removeGroupCancelPushBtn = self.removeGroupCancelPushButton
+        self.removeGroupCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+
+        self.populateRemoveGroupDialog()
+    
+
+    def populateRemoveGroupDialog(self):
+        databaseOperation = pgModule.DatabaseOperation()
+        databaseOperation.getAllRowsFromTable(
+            self.connectionArguments, 'public.jakoryhma')
+        if databaseOperation.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation.errorMessage,
+                databaseOperation.detailedMessage
+                )
+        else:
+            self.groupIdList = prepareData.prepareComboBox(
+                databaseOperation, self.removeGroupCB, 2, 0)
+    
+    def removeGroup(self):
+        try:
+            groupChosenItemIx = self.removeGroupCB.currentIndex()
+            groupId = self.groupIdList[groupChosenItemIx]
+            
+            table = 'public.jakoryhma'
+            limit = f"public.jakoryhma.ryhma_id = {groupId}"
+        except Exception:
+            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
+
+        databaseOperation1 = pgModule.DatabaseOperation()
+        databaseOperation1.getAllRowsFromTable(self.connectionArguments, 'public.jakoryhma_liitokset')
+        groupConnections = databaseOperation1.resultSet
+        alert = 0
+
+        for id in groupConnections:
+            if id[0] == groupId:
+                connectionWarning = 'Et voi poistaa ryhmää joka on lisätty toiseen tauluun'
+                alert = 1
+                self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen',connectionWarning)
+                break
+
+        if alert != 1:
+            databaseOperation2 = pgModule.DatabaseOperation()
+            databaseOperation2.deleteFromTable(self.connectionArguments, table, limit)
+            if databaseOperation2.errorCode != 0:
+                self.alert(
+                    'Vakava virhe',
+                    'Tietokantaoperaatio epäonnistui',
+                    databaseOperation2.errorMessage,
+                    databaseOperation2.detailedMessage
+                    )
+            else:
+                # Update the page to show new data and clear 
+                success = SuccessfulOperationDialog()
+                success.exec()
+                self.populateRemoveGroupDialog()
+
+    def closeDialog(self):
+        self.close()

--- a/desktopApp/dialogs/removeDialogues/Member.py
+++ b/desktopApp/dialogs/removeDialogues/Member.py
@@ -1,0 +1,95 @@
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import QDialog, QComboBox, QLabel, QPushButton
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame, SuccessfulOperationDialog
+import pgModule as pgModule
+import prepareData as prepareData
+from datetime import date
+
+class Member(DialogFrame):
+    """Creates a dialog to remove member from database"""
+    # TODO: Change from using delete from database to changing members status to deactive('poistunut')
+    # Constructor
+    def __init__(self):
+
+        super().__init__()
+
+        loadUi("ui/removeMemberDialog.ui", self)
+
+        self.setWindowTitle('Poista jäsen')
+
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+
+        # Elements
+        self.removeMemberCB = self.removeMemberComboBox
+        
+        self.removeMemberPushBtn = self.removeMemberPushButton
+        self.removeMemberPushBtn.clicked.connect(self.removeMember) # Signal
+        self.removeMemberCancelPushBtn = self.removeMemberCancelPushButton
+        self.removeMemberCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+
+        # Populate the member combo box
+        self.populateRemoveMemberDialog()
+
+    
+
+    def populateRemoveMemberDialog(self):
+        databaseOperation2 = pgModule.DatabaseOperation()
+        databaseOperation2.getAllRowsFromTable(
+            self.connectionArguments, 'public.nimivalinta')
+        if databaseOperation2.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation2.errorMessage,
+                databaseOperation2.detailedMessage
+                )
+        else:
+            self.memberIdList = prepareData.prepareComboBox(
+                databaseOperation2, self.removeMemberCB, 1, 0)
+    
+
+    def removeMember(self):
+        try:
+            memberChosenItemIx = self.removeMemberCB.currentIndex()
+            memberId = self.memberIdList[memberChosenItemIx]
+            
+            table = 'public.jasen'
+            limit = f"public.jasen.jasen_id = {memberId}"
+        except Exception:
+            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
+        
+        databaseOperation1 = pgModule.DatabaseOperation()
+        databaseOperation1.getAllRowsFromTable(self.connectionArguments, 'public.jasen_liitokset')
+        memberConnections = databaseOperation1.resultSet
+        alert = 0
+
+        for id in memberConnections:
+            if id[0] == memberId:
+                connectionWarning = 'Et voi poistaa jäsentä joka on lisätty toiseen tauluun'
+                alert = 1
+                self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen',connectionWarning)
+                break
+
+        if alert != 1:
+            databaseOperation2 = pgModule.DatabaseOperation()
+            databaseOperation2.deleteFromTable(self.connectionArguments, table, limit)
+            if databaseOperation2.errorCode != 0:
+                self.alert(
+                    'Vakava virhe',
+                    'Tietokantaoperaatio epäonnistui',
+                    databaseOperation2.errorMessage,
+                    databaseOperation2.detailedMessage
+                    )
+            else:
+                # Update the page to show new data and clear 
+                success = SuccessfulOperationDialog()
+                success.exec()
+                self.populateRemoveMemberDialog()
+
+    def closeDialog(self):
+        self.close()

--- a/desktopApp/dialogs/removeDialogues/Party.py
+++ b/desktopApp/dialogs/removeDialogues/Party.py
@@ -1,0 +1,93 @@
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import QDialog, QComboBox, QLabel, QPushButton
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame, SuccessfulOperationDialog
+import pgModule as pgModule
+import prepareData as prepareData
+from datetime import date
+
+class Party(DialogFrame):
+    """Creates a dialog to remove party from database"""
+    
+    # Constructor
+    def __init__(self):
+
+        super().__init__()
+
+        loadUi("ui/removePartyDialog.ui", self)
+
+        self.setWindowTitle('Poista seurue')
+
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+
+        # Elements
+        self.removePartyCB = self.removePartyComboBox
+        
+        
+        self.removePartyRemovePushBtn = self.removePartyRemovePushButton
+        self.removePartyRemovePushBtn.clicked.connect(self.removeParty) # Signal
+        self.removePartyCancelPushBtn = self.removePartyCancelPushButton
+        self.removePartyCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+
+        self.populateRemovePartyDialog()
+    
+
+    def populateRemovePartyDialog(self):
+        databaseOperation2 = pgModule.DatabaseOperation()
+        databaseOperation2.getAllRowsFromTable(
+            self.connectionArguments, 'public.seurue')
+        if databaseOperation2.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation2.errorMessage,
+                databaseOperation2.detailedMessage
+                )
+        else:
+            self.partyIdList = prepareData.prepareComboBox(
+                databaseOperation2, self.removePartyCB, 2, 0)
+
+    def removeParty(self):
+        try:
+            partyChosenItemIx = self.removePartyCB.currentIndex()
+            partyId = self.partyIdList[partyChosenItemIx]
+            
+            table = 'public.seurue'
+            limit = f"public.seurue.seurue_id = {partyId}"
+        except Exception:
+            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
+
+        databaseOperation1 = pgModule.DatabaseOperation()
+        databaseOperation1.getAllRowsFromTable(self.connectionArguments, 'public.seurue_liitokset')
+        partyConnections = databaseOperation1.resultSet
+        alert = 0
+
+        for id in partyConnections:
+            if id[0] == partyId:
+                connectionWarning = 'Et voi poistaa seuruetta joka on lisätty toiseen tauluun'
+                alert = 1
+                self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen', connectionWarning)
+                break
+
+        if alert != 1:
+            databaseOperation2 = pgModule.DatabaseOperation()
+            databaseOperation2.deleteFromTable(self.connectionArguments, table, limit)
+            if databaseOperation2.errorCode != 0:
+                self.alert(
+                    'Vakava virhe',
+                    'Tietokantaoperaatio epäonnistui',
+                    databaseOperation2.errorMessage,
+                    databaseOperation2.detailedMessage
+                    )
+            else:
+                # Update the page to show new data and clear 
+                success = SuccessfulOperationDialog()
+                success.exec()
+                self.populateRemovePartyDialog()
+
+    def closeDialog(self):
+        self.close()


### PR DESCRIPTION
Refactored class definitions in **Remove dialogue Window module** to separate modules.

Modified Jahtirekisteri.py file imports to match new modules.

<img width="746" alt="image" src="https://github.com/eeroleppalehto/Jahtirekisteri/assets/111054270/9ee52dcf-7457-4fa4-af7d-3f265f9292a4">

<img width="605" alt="image" src="https://github.com/eeroleppalehto/Jahtirekisteri/assets/111054270/bf3fef0c-9b34-4693-9b74-72116b6c55f8">

