### PR TITLE
55 explore chart libraries for react native and draft some charts

### DIFF
--- a/mobileApp/data/groupData.ts
+++ b/mobileApp/data/groupData.ts
@@ -1,0 +1,52 @@
+export const groupData =
+[
+    {
+      ryhma_id: 1,
+      ryhman_nimi: "Ryhmä1",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 325
+    },
+    {
+      ryhma_id: 2,
+      ryhman_nimi: "Ryhmä2",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 355
+    },
+    {
+      ryhma_id: 3,
+      ryhman_nimi: "Ryhmä3",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 248
+    },
+    {
+      ryhma_id: 4,
+      ryhman_nimi: "Ryhmä4",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 212
+    },
+    {
+      ryhma_id: 5,
+      ryhman_nimi: "Ryhmä5",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 308
+    },
+    {
+      ryhma_id: 6,
+      ryhman_nimi: "Ryhmä6",
+      seurue_id: 1,
+      osuus: 4,
+      maara: 292
+    },
+    {
+      ryhma_id: 7,
+      ryhman_nimi: "Ryhmä7",
+      seurue_id: 1,
+      osuus: 3.5,
+      maara: 211
+    }
+]

--- a/mobileApp/package-lock.json
+++ b/mobileApp/package-lock.json
@@ -25,7 +25,9 @@
         "react-native-reanimated": "~2.14.4",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0",
-        "react-native-tab-view": "^3.5.2"
+        "react-native-svg": "13.4.0",
+        "react-native-tab-view": "^3.5.2",
+        "victory-native": "^36.6.11"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -5391,6 +5393,60 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.6.tgz",
+      "integrity": "sha512-NHkizg870sKYQn45oZT5ItoHqcgRgJD7KAiWZp4Udc6YdrFH2W0tZ2vv4shRHP+SXHoJ1G8B4I1GWb5oQSGypA=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.4.tgz",
+      "integrity": "sha512-eq1ZeTj0yr72L8MQk6N6heP603ubnywSDRfNpi5enouR112HzGLS6RIvExCzZTraFF4HdzNpJMwA/zGiMoHUUw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.2.tgz",
+      "integrity": "sha512-NN4CXr3qeOUNyK5WasVUV8NCSAx/CRVcwcb0BuuS1PiTqwIm6ABi1SyasLZ/vsVCFDArF+W4QiGzSry1eKYQ7w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
+    },
     "node_modules/@types/hammerjs": {
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
@@ -6445,6 +6501,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -7263,11 +7324,172 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -7435,6 +7657,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "dependencies": {
+        "delaunator": "^4.0.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7498,6 +7733,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7527,6 +7813,17 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -9890,6 +10187,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -11300,6 +11605,11 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11534,6 +11844,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ=="
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -12900,6 +13215,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
@@ -13855,6 +14181,11 @@
         }
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-freeze": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
@@ -14013,6 +14344,19 @@
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-13.4.0.tgz",
+      "integrity": "sha512-B3TwK+H0+JuRhYPzF21AgqMt4fjhCwDZ9QUtwNstT5XcslJBXC0FoTkdZo8IEb1Sv4suSqhZwlAY6lwOv3tHag==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
       },
       "peerDependencies": {
         "react": "*",
@@ -16206,6 +16550,485 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-36.6.11.tgz",
+      "integrity": "sha512-pXtD0gEBw1wohctaeDDWAUwX+qR9OyKyUeI0bi/rmSPNf84TinIf1bWuAuUuEPb2v90ASLVkuz0nVAP//7FOdQ==",
+      "dependencies": {
+        "victory-area": "^36.6.11",
+        "victory-axis": "^36.6.11",
+        "victory-bar": "^36.6.11",
+        "victory-box-plot": "^36.6.11",
+        "victory-brush-container": "^36.6.11",
+        "victory-brush-line": "^36.6.11",
+        "victory-candlestick": "^36.6.11",
+        "victory-canvas": "^36.6.11",
+        "victory-chart": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-create-container": "^36.6.11",
+        "victory-cursor-container": "^36.6.11",
+        "victory-errorbar": "^36.6.11",
+        "victory-group": "^36.6.11",
+        "victory-histogram": "^36.6.11",
+        "victory-legend": "^36.6.11",
+        "victory-line": "^36.6.11",
+        "victory-pie": "^36.6.11",
+        "victory-polar-axis": "^36.6.11",
+        "victory-scatter": "^36.6.11",
+        "victory-selection-container": "^36.6.11",
+        "victory-shared-events": "^36.6.11",
+        "victory-stack": "^36.6.11",
+        "victory-tooltip": "^36.6.11",
+        "victory-voronoi": "^36.6.11",
+        "victory-voronoi-container": "^36.6.11",
+        "victory-zoom-container": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.11.tgz",
+      "integrity": "sha512-M/wQ0ryms6WpqGzpv+BMNfCLy0dlOtIxAuYgXJYwwDu55noAMbWlFahIzfllpjTmFOyCpCXF7EDraC3n2xRRFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.11.tgz",
+      "integrity": "sha512-f2PUbEsE5wYXKRrgSYdoPRV6QXKNrZjTcd8YlymVGWsouJEFRZFOig8N3yU5lM7OuP98tOdurk4I91Py6NlXrA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.11.tgz",
+      "integrity": "sha512-ANXZIYiDcvC1k3fvGbE8qHOi0POGOsYbzTgP/SBHXh9VQYa/NaYGZT3RO1mxp8wgpwaF+NZYZNC8mMO1pvcB2w==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.6.11.tgz",
+      "integrity": "sha512-+J7Hb0Vf6cQe+qZyRhm6sM7V7AMS43jSTXnrFtRP7Bn+HdAb7p2S7h8abtgUhg3uVeTQa9UUqJBmC/maP8V3Nw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.11.tgz",
+      "integrity": "sha512-o0pPKzfQhKRlYNYUx3tHjuv9iTXqvgRtmu59L/h6l11DPaRo+jcHDBKEDRuoZxTinR/a1yqfLEJ1i9QgSE8o6w==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.6.11.tgz",
+      "integrity": "sha512-AYZvqq25nc7wOP4w7ysWAkhZnkuG28zah+6M1gJqcdeZov6dkiblda66vpwDOR1sCAGiHtLGR1pkUm+p02ikJw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.6.11.tgz",
+      "integrity": "sha512-4R2aYq4opG7ONv//OjJmSPXfVgPdb3xoNiBPfs832Kon0vlfcIltvge34YEn0qkanlcp1Vg/GvxvKa/kxR45JA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.6.11.tgz",
+      "integrity": "sha512-0lzX9JabP6xpkn5VlHPYduYmg2dyMzvXGEbD17ZQNljOhvczkKkbOlps+v94y8MGsiXRLvkpwBMYf4V8m60lFQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-bar": "^36.6.11",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.11.tgz",
+      "integrity": "sha512-t4RIeLT6PJxZaDqNeawtIPxuA48k98kBvYbEV9XEPrS3TPAYsrB6lgXjZKLoItYLh63Ry4nqZAnPti4RD0uTfQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-axis": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-polar-axis": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.11.tgz",
+      "integrity": "sha512-aYhFIRu8NQMwW/JbgqoAG7w0lUYbTB1Achx4mmBc6aL8RMkv6LhD/PFwjT3TLpH0AoEs3Rpty2g0UQ+7ulE7dA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.11.tgz",
+      "integrity": "sha512-Ve96DE9XDifmT2Bh/6Ptz7cgIV5DC2GYsr0Rl6I0sF6S02IH3V02NLpkcTthTRJHAvC9MkHwjiBlvFEZsXHOtg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-cursor-container": "^36.6.11",
+        "victory-selection-container": "^36.6.11",
+        "victory-voronoi-container": "^36.6.11",
+        "victory-zoom-container": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.11.tgz",
+      "integrity": "sha512-rdQAZb3RGYfijjqIQkuPGLNY5UOhuqyzlxQFaVtkpkDSZKiPMtbfLvR7F0Yfa9cs8OeQU0KAtAiK8R33o7su/Q==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.6.11.tgz",
+      "integrity": "sha512-Umu8MZ2XtMNCxr8rRcf421FLywJlvQY86sGNqePaBbar4rqk6sqWAU8HKzttNjCEQ0xh579LmskleiutEBFf4g==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.11.tgz",
+      "integrity": "sha512-PTRrH31gsGk3KFzeTzAkyvgjtilWYHWkx06oouh70KuAJ7f+9pRMrRMal8v+npH6a8Wp0KKW198AqpkPaZqHyQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.6.11.tgz",
+      "integrity": "sha512-WOMfvshfzAgGn1Zh+/fLVW0kxQrVKYACFCdsKDEYmuG8dGvqmPilI3oljAqiYrafNagwVv+Otc0NNgW8ydLHcA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.11.tgz",
+      "integrity": "sha512-eL310Qh3WcZyjFI18hABVodwHpgZtokHD3r5HKpgZVY8MWkMD9mXErphWbkNHTVi5ya+I3QbRQ7ToRbPUl/Jog==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.11.tgz",
+      "integrity": "sha512-SDQCS6qDSixnYPB1kHEQsue06N6x2cxkIA6uqL45LRFMkKWG4OtwTBORVhtK6lfKzq1OvJs3msoZ+uoRIW1gaA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-native": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-native/-/victory-native-36.6.11.tgz",
+      "integrity": "sha512-LAUcDHVO7qR9L2rxP0nyBPAI+XQF5/7554zv6PEeBWU0sLszw4loFnbexlc/LCCD0u+VjEiJvsGLk6ihaJKKLQ==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory": "^36.6.11",
+        "victory-area": "^36.6.11",
+        "victory-axis": "^36.6.11",
+        "victory-bar": "^36.6.11",
+        "victory-box-plot": "^36.6.11",
+        "victory-brush-container": "^36.6.11",
+        "victory-brush-line": "^36.6.11",
+        "victory-candlestick": "^36.6.11",
+        "victory-chart": "^36.6.11",
+        "victory-core": "^36.6.11",
+        "victory-create-container": "^36.6.11",
+        "victory-cursor-container": "^36.6.11",
+        "victory-errorbar": "^36.6.11",
+        "victory-group": "^36.6.11",
+        "victory-histogram": "^36.6.11",
+        "victory-legend": "^36.6.11",
+        "victory-line": "^36.6.11",
+        "victory-pie": "^36.6.11",
+        "victory-polar-axis": "^36.6.11",
+        "victory-scatter": "^36.6.11",
+        "victory-selection-container": "^36.6.11",
+        "victory-shared-events": "^36.6.11",
+        "victory-stack": "^36.6.11",
+        "victory-tooltip": "^36.6.11",
+        "victory-voronoi": "^36.6.11",
+        "victory-voronoi-container": "^36.6.11",
+        "victory-zoom-container": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.11.tgz",
+      "integrity": "sha512-vQPAzrubo3BX/1pujSlKKTBGNSj/8fxUJ0vSZPZ6EE1y6SRnPJoLYi2OkDQVT1s3rM9xvW00SflCD3GO/Z3xWA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11",
+        "victory-vendor": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.11.tgz",
+      "integrity": "sha512-wDkyY1rKQTRUVt4+e0QNQgSIJCqXazNhkjWXla8ZWj52GzPP/QSDuzr8SO1oHA3++1jOpdD0R2FTxm+pAea/Yw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.11.tgz",
+      "integrity": "sha512-x46AfmhiKijXe59kqm7xI0CCjbY8J0VB02HUN3TynMx7xzhW2yOP+QQqgyk+C4im/MS33HKU402Q7cUfF3pgtw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.11.tgz",
+      "integrity": "sha512-pRQz++0ERZVuIgxpmqLkDgf6hiCAS2m8iGcox8tryWzE1NpADG/IJiHh3AeJgGeiLNMeoJ48hsOZP1C9CCxwrQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.11.tgz",
+      "integrity": "sha512-ia6ijfgfYMb+gGFPEq4F6rqzB9p5EkjKpjvmEv4Ww7VjrtdORu7PPfAgTxXw/9QgFSq4iOUnDtzjObABua09fQ==",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.11.tgz",
+      "integrity": "sha512-kE/915RdcKes69WpxZ5j6MyCIJqdzIZnzIg6OArBeDlD+LuinNb2oNxYpMXzur1KFSyk5PCUckHgEbR2XLoXrw==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-shared-events": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.11.tgz",
+      "integrity": "sha512-YxAPkGAqTYOIW4aE5InGFABmYjiBfuQFjCe9hwFGvIC/Uqn202xgs5kYVEZXUX3vc9W8XOl7plaQJzmtr2ZZBQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.11.tgz",
+      "integrity": "sha512-nT8kCiJp8dQh8g991J/R5w5eE2KnO8EAIP0xocWlh9l2okngMWglOPoMZzJvek8Q1KUc4XE/mJxTZnvOB1sTYg==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.6.11.tgz",
+      "integrity": "sha512-Hu1S8HsM0YOUvzW0cp2LnEvgh6a+dXHkGfaI+Qyyz5P8uXFgBcBvvhzLbgawkrIOgbX/jU5Vpketvhm4ByuAqQ==",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.11.tgz",
+      "integrity": "sha512-KNB814e5uhs00oNFdkPucXMlpNILnWabHM7iKLBz26nlgqiu6dctZZoWU+HKjxbPkHdic6JQsg28Nk5bThaulw==",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.6.11",
+        "victory-tooltip": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.11.tgz",
+      "integrity": "sha512-DRS12HZEmy5oJanlnSK9Wtp/6HQQbwvK0idVU+Lhf2lw3r9gauWp/ymWwWzaHd7Mn5cCODuNW1le2bqb71j3wg==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.8.1",
+        "victory-core": "^36.6.11"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/vlq": {

--- a/mobileApp/package.json
+++ b/mobileApp/package.json
@@ -26,7 +26,9 @@
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
-    "react-native-tab-view": "^3.5.2"
+    "react-native-tab-view": "^3.5.2",
+    "victory-native": "^36.6.11",
+    "react-native-svg": "13.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/mobileApp/src/components/BottomNav.tsx
+++ b/mobileApp/src/components/BottomNav.tsx
@@ -4,6 +4,9 @@ import { Text } from "react-native-paper";
 import MaintenanceNav from "./MaintenanceNav";
 import { BottomNavParamList } from "../NavigationTypes";
 
+import VictoryTest from "../screens/GraphScreen/VictoryChart";
+import VictoryGroupChart from "../screens/GraphScreen/VictoryGroupChart";
+
 const Tab = createMaterialBottomTabNavigator<BottomNavParamList>();
 
 const Placeholder = () => {
@@ -13,7 +16,7 @@ const Placeholder = () => {
 function BottomNav() {
     return (
         <Tab.Navigator>
-            <Tab.Screen name="Grafiikka" component={Placeholder} />
+            <Tab.Screen name="Grafiikka" component={VictoryGroupChart} />
             <Tab.Screen name="Kaadot" component={Placeholder} />
             <Tab.Screen name="Ylläpito" component={MaintenanceNav} />
         </Tab.Navigator>

--- a/mobileApp/src/components/CustomAppBar.tsx
+++ b/mobileApp/src/components/CustomAppBar.tsx
@@ -7,7 +7,7 @@ import { Route } from "@react-navigation/native";
 import { RootStackScreenProps } from "../NavigationTypes";
 
 function myGetHeaderTitle(route: Route<string>) {
-    const routeName = getFocusedRouteNameFromRoute(route) ?? "Main";
+    const routeName = getFocusedRouteNameFromRoute(route) ?? "Grafiikka";
 
     switch (routeName) {
         case "Ylläpito":

--- a/mobileApp/src/components/DrawerNav.tsx
+++ b/mobileApp/src/components/DrawerNav.tsx
@@ -19,6 +19,7 @@ function DrawerNav() {
     return (
         <Drawer.Navigator
             id="DrawerNav"
+            initialRouteName="RootStack"
             drawerContent={({ navigation }) => (
                 <DrawerContent navigation={navigation} />
             )}

--- a/mobileApp/src/screens/GraphScreen/VictoryChart.tsx
+++ b/mobileApp/src/screens/GraphScreen/VictoryChart.tsx
@@ -1,0 +1,54 @@
+import { StyleSheet, View } from "react-native";
+import {
+    VictoryBar,
+    VictoryChart,
+    VictoryTheme,
+    VictoryAxis,
+} from "victory-native";
+import { useTheme } from "react-native-paper";
+
+const data = [
+    { quarter: "Ryhmä1", earnings: 13000 },
+    { quarter: "Ryhmä1", earnings: 16500 },
+    { quarter: "Ryhmä2", earnings: 16500 },
+    { quarter: "Ryhmä3", earnings: 14250 },
+    { quarter: "Ryhmä4", earnings: 19000 },
+];
+
+export default function VictoryTest() {
+    const theme = useTheme();
+
+    return (
+        <View style={styles.container}>
+            <VictoryChart
+                width={350}
+                horizontal={true}
+                theme={VictoryTheme.material}
+                domainPadding={20}
+            >
+                <VictoryBar
+                    data={data}
+                    x="quarter"
+                    y="earnings"
+                    cornerRadius={3}
+                    style={{
+                        data: {
+                            fill: theme.colors.primary,
+                            stroke: theme.colors.primary,
+                            strokeWidth: 2,
+                        },
+                    }}
+                />
+            </VictoryChart>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "#f5fcff",
+    },
+});

--- a/mobileApp/src/screens/GraphScreen/VictoryGroupChart.tsx
+++ b/mobileApp/src/screens/GraphScreen/VictoryGroupChart.tsx
@@ -1,0 +1,35 @@
+import { VictoryChart, VictoryGroup, VictoryBar } from "victory-native";
+
+export default function VictoryGroupChart() {
+    return (
+        <VictoryChart>
+            <VictoryGroup
+                offset={30}
+                colorScale={"qualitative"}
+                // horizontal={true}
+            >
+                <VictoryBar
+                    data={[
+                        { x: "Ryhmä1", y: 1 },
+                        { x: "Ryhmä2", y: 2 },
+                        { x: "Ryhmä3", y: 5 },
+                    ]}
+                />
+                <VictoryBar
+                    data={[
+                        { x: "Ryhmä1", y: 2 },
+                        { x: "Ryhmä2", y: 1 },
+                        { x: "Ryhmä3", y: 7 },
+                    ]}
+                />
+                {/* <VictoryBar
+                    data={[
+                        { x: "Ryhmä1", y: 3 },
+                        { x: "Ryhmä2", y: 4 },
+                        { x: "Ryhmä3", y: 9 },
+                    ]}
+                /> */}
+            </VictoryGroup>
+        </VictoryChart>
+    );
+}

--- a/mobileApp/src/utils/parseCharts.ts
+++ b/mobileApp/src/utils/parseCharts.ts
@@ -1,0 +1,10 @@
+import { groupData } from "../../data/groupData";
+
+interface GroupData {
+    ryhma_id: number;
+    ryhman_nimi: string;
+    seurue_id: number;
+    osuus: number;
+    maara: number;
+}
+


### PR DESCRIPTION
Tested the chart libraries listed in the issue with no success as all of them were either not compatible with expo or were not up to date with current React Native version. Because of that ended up with [Victory Native](https://formidable.com/open-source/victory/docs/native/) which worked out of the box in the application.