### PR TITLE
38 fix bug in share page in desktop application

### DIFF
--- a/desktopApp/prepareData.py
+++ b/desktopApp/prepareData.py
@@ -111,6 +111,7 @@ def parseSharedPortionOfShot(tableData):
                 animal = row[1]
                 sharedPortions += portionDict[row[2]]
                 amount += row[3]
+                shotUsagePortion = row[4]/100
                 
         # Calculate shared portions and append values to result table data
         sharedPortions = f"{int(sharedPortions*100/(4*shotUsagePortion))}%"

--- a/desktopApp/prepareData.py
+++ b/desktopApp/prepareData.py
@@ -79,3 +79,41 @@ def prepareComboBox(resultObject, comboBox, ixToShow, ixToReturn):
     
     comboBox.addItems(cBItems) # Populate the combo box
     return cBValuesOfInterest       
+
+def parseSharedPortionOfShot(tableData):
+    """Function that parses data from table data to be view in the shared portion of shot table
+
+    Args:
+        tableData (list): Contains list of tuples containing (id, animal, portion, amount, usagePortion)
+
+    Returns:
+        list: Contains list of tuples containing (id, animal, sharedPortion, amount)
+    """
+    
+    # Generate ids to new list and remove duplicates
+    sharedKillsListId = [ row[0] for row in tableData ]
+    sharedKillsListId = list(dict.fromkeys(sharedKillsListId))
+    
+    portionDict = {'Koko': 4, 'Puolikas': 2, 'Neljännes': 1}
+    
+    resultTableData = []
+    # Iterate through ids
+    for id in sharedKillsListId:
+        # Initialize variables
+        animal = ""
+        sharedPortions = 0
+        amount = 0
+        shotUsagePortion = 0
+
+        # Iterate through table data
+        for row in tableData:
+            if row[0] == id:
+                animal = row[1]
+                sharedPortions += portionDict[row[2]]
+                amount += row[3]
+                
+        # Calculate shared portions and append values to result table data
+        sharedPortions = f"{int(sharedPortions*100/(4*shotUsagePortion))}%"
+        resultTableData.append((id, animal, sharedPortions, amount))
+    
+    return resultTableData

--- a/desktopApp/tabs/shareTabWidget.py
+++ b/desktopApp/tabs/shareTabWidget.py
@@ -186,37 +186,14 @@ class Ui_shareTabWidget(QScrollArea, QWidget):
         else:
             # Process data to be shown in sharedPortionsTableWidget
             try:
-                sharedPortionsData = databaseOperation6.resultSet
-
-                # Generate id to new list and remove duplicates
-                sharedKillsListID = [ row[0] for row in sharedPortionsData ]
-                sharedKillsListID = list(dict.fromkeys(sharedKillsListID))
-
-                # Modify database attributes to accommodate for edited table
-                databaseOperation6.columnHeaders[2] = 'Jaettu'
-                databaseOperation6.rows = len(sharedKillsListID)
-
-                portionDict = {'Koko': 4, 'Puolikas': 2, 'Neljännes': 1}
-
-                # Iterate through result set and sum amounts and portions for each id
-                newData = []
-                for id in sharedKillsListID:
-                    animal = ""
-                    sharedPortions = 0
-                    amount = 0
-                    shotUsagePortion = 0
-
-                    for row in sharedPortionsData:
-                        if row[0] == id:
-                            animal = row[1]
-                            sharedPortions += portionDict[row[2]]
-                            amount += row[3]
-                            shotUsagePortion += row[4]/100
-                    sharedPortions = f"{int(sharedPortions*100/(4*shotUsagePortion))}%"
-                    newData.append((id, animal, sharedPortions, amount))
+                # parse the data from the view to readable format
+                tableData = prepareData.parseSharedPortionOfShot(databaseOperation6.resultSet)
                 
-                # Replace resultSet with new data
-                databaseOperation6.resultSet = newData
+                # Set row count and column headers to match the data
+                databaseOperation6.rows = len(tableData)
+                databaseOperation6.columnHeaders[2] = 'Jaettu'
+                databaseOperation6.resultSet = tableData
+                
                 prepareData.prepareTable(databaseOperation6, self.sharedPortionsTW)
                 self.sharedPortionsTW.setColumnHidden(4, True)
             except:


### PR DESCRIPTION
Fixed the bug that caused the portion of the shot percentage show its value incorrectly. Cause of the bug was the **usagePortion** value, which was being added up multiple times if there was multiple cases of shares for the same kill, instead of just being set once.

Also refactored the code that generated the data for the table to its own function.