### PR TITLE
39 fix bug in shot page in desktop application

### DIFF
--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -215,6 +215,7 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             self.shotLicenseYearCB.clear()
             yearList = [row[2] for row in databaseOperation8.resultSet]
             yearList = list(set(yearList))
+            yearList.sort(reverse=True)
             self.shotLicenseYearCB.addItems(yearList)
 
     def populateShotLicenceTW(self):

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -210,12 +210,14 @@ class Ui_killTabWidget(QScrollArea, QWidget):
                 databaseOperation8.detailedMessage
                 )
         else:
-            self.shotLicenseYearCB.clear() # FIXME: As this is called in populateKillPage, it clears the combo box every time the page is opened which sends a signal that crashes the app
+            self.shotLicenseYearCB.clear()
             yearList = [row[2] for row in databaseOperation8.resultSet]
             yearList = list(set(yearList))
             self.shotLicenseYearCB.addItems(yearList)
 
     def populateShotLicenceTW(self):
+        if self.shotLicenseYearCB.currentText() == '':
+            return
         year = int(self.shotLicenseYearCB.currentText())
 
         databaseOperation = pgModule.DatabaseOperation()

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -175,6 +175,8 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             prepareData.prepareComboBox(
                 databaseOperation6, self.shotUsage2CB, 1, 0)  
 
+        self.populateLicenceCB()
+
         if self.shotLicenseYearCB.currentText() != '':
             databaseOperation7 = pgModule.DatabaseOperation()
             databaseOperation7.callFunction(

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -57,22 +57,6 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             databaseOperation = pgModule.DatabaseOperation()
             self.connectionArguments = databaseOperation.readDatabaseSettingsFromFile('connectionSettings.dat')
 
-        databaseOperation8 = pgModule.DatabaseOperation()
-        databaseOperation8.getAllRowsFromTable(
-            self.connectionArguments, 'public.lupa')
-        if databaseOperation8.errorCode != 0:
-            self.alert(
-                'Vakava virhe',
-                'Tietokantaoperaatio epäonnistui',
-                databaseOperation8.errorMessage,
-                databaseOperation8.detailedMessage
-                )
-        else:
-            self.shotLicenseYearCB.clear()
-            yearList = [row[2] for row in databaseOperation8.resultSet]
-            yearList = list(set(yearList))
-            self.shotLicenseYearCB.addItems(yearList)
-        
         self.shotLicenseYearCB.currentIndexChanged.connect(self.populateShotLicenceTW) # Signal
 
         self.populateKillPage()
@@ -212,7 +196,24 @@ class Ui_killTabWidget(QScrollArea, QWidget):
                 'Ei löytynyt vuotta, jolta hakea lupatietoja',
                 'Could not find year to fetch licence data from, try adding a license in the license page first'
                 )
+            
         
+    def populateLicenceCB(self):
+        databaseOperation8 = pgModule.DatabaseOperation()
+        databaseOperation8.getAllRowsFromTable(
+            self.connectionArguments, 'public.lupa')
+        if databaseOperation8.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation8.errorMessage,
+                databaseOperation8.detailedMessage
+                )
+        else:
+            self.shotLicenseYearCB.clear() # FIXME: As this is called in populateKillPage, it clears the combo box every time the page is opened which sends a signal that crashes the app
+            yearList = [row[2] for row in databaseOperation8.resultSet]
+            yearList = list(set(yearList))
+            self.shotLicenseYearCB.addItems(yearList)
 
     def populateShotLicenceTW(self):
         year = int(self.shotLicenseYearCB.currentText())


### PR DESCRIPTION
Extracted the code that populates the licenceCB to its own method and added it to **populateKillPage** method to update the CB on each reload.

To avoid further errors I added check to see if the CB is empty in the **populateLicenceTW** method as when the tab is reloaded the CB is cleared which sends signal to populate the table which would throw an error as the CB is empty.