### PR TITLE
69 add functionality to remove membership from db

### DIFF
--- a/desktopApp/dialogs/removeDialogues/Membership.py
+++ b/desktopApp/dialogs/removeDialogues/Membership.py
@@ -1,0 +1,96 @@
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import QDialog, QComboBox, QLabel, QPushButton
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame, SuccessfulOperationDialog
+import pgModule as pgModule
+import prepareData as prepareData
+from dialogs.messageModule import PopupMessages as msg
+
+class Membership(DialogFrame):
+    """Creates a dialog to remove membership from database"""
+    def __init__(self):
+
+        super().__init__()
+
+        loadUi("ui/removeMembershipDialog.ui", self)
+
+        self.setWindowTitle('Poista jäsenyys')
+        
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+        
+        # Elements
+        self.removeMembershipCB = self.removeMembershipComboBox
+        
+        self.removeMembershipPushBtn = self.removeMembershipPushButton
+        self.removeMembershipPushBtn.clicked.connect(self.removeMembership) # Signal
+        self.removeMembershipCancelPushBtn = self.removeMembershipCancelPushButton
+        self.removeMembershipCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+        
+        # Populate the membership combo box
+        self.populateRemoveMembershipDialog()
+        
+    def populateRemoveMembershipDialog(self):
+        databaseOperation2 = pgModule.DatabaseOperation()
+        databaseOperation2.getAllRowsFromTable(
+            self.connectionArguments, 'public.jasenyys_nimella_ryhmalla')
+        if databaseOperation2.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation2.errorMessage,
+                databaseOperation2.detailedMessage
+                )
+        else:
+            # Process the data to be shown in the combo box
+            
+            results = databaseOperation2.resultSet
+            newResults = []
+            
+            # Read colums 0, 4 and 7 from each row in the result set
+            # and generate a string from them to be viewed in the combo box
+            for row in results:
+                newResults.append((f"{row[0]} | {row[4]} | Osuus: {row[7]}", row[1]))
+                
+            databaseOperation2.resultSet = newResults
+            
+            self.membershipIdList = prepareData.prepareComboBox(
+                databaseOperation2, self.removeMembershipCB, 0, 1)
+            
+    def removeMembership(self):
+        try:
+            membershipChosenItemIx = self.removeMembershipCB.currentIndex()
+            membershipId = self.membershipIdList[membershipChosenItemIx]
+            
+            table = 'public.jasenyys'
+            limit = f"public.jasenyys.jasenyys_id = {membershipId}"
+        except Exception as e:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                str(e),
+                str(e)
+                )
+        
+        databaseOperation = pgModule.DatabaseOperation()
+        databaseOperation.deleteFromTable(self.connectionArguments, table, limit)
+        if databaseOperation.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation.errorMessage,
+                databaseOperation.detailedMessage
+                )
+        else:
+            
+            """ successfulOperationDialog = SuccessfulOperationDialog()
+            successfulOperationDialog.exec() """
+            msg().successMessage('Jäsenyys poistettu')
+            self.populateRemoveMembershipDialog()
+         
+            
+    def closeDialog(self):
+        self.close()

--- a/desktopApp/tabs/maintenanceTabWidget.py
+++ b/desktopApp/tabs/maintenanceTabWidget.py
@@ -10,6 +10,7 @@ import dialogs.addDialogueWindow as addDialogueWindow
 import dialogs.removeDialogues.Group as removeDialogueWindowGroup
 import dialogs.removeDialogues.Member as removeDialogueWindowMember
 import dialogs.removeDialogues.Party as removeDialogueWindowParty
+import dialogs.removeDialogues.Membership as removeDialogueWindowMembership
 
 import dialogs.editDialogues.Company as editDialogueWindowCompany
 import dialogs.editDialogues.Group as editDialogueWindowGroup
@@ -47,6 +48,10 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
         self.maintenanceEditGroupPushBtn.clicked.connect(self.openEditGroupDialog) # Signal
         self.maintenanceEditPartyPushBtn = self.maintenanceEditPartyPushButton
         self.maintenanceEditPartyPushBtn.clicked.connect(self.openEditPartyDialog) # Signal
+        
+        self.maintenanceRemoveMembershipPB = self.maintenanceRemoveMembershipPushButton
+        self.maintenanceRemoveMembershipPB.clicked.connect(self.openRemoveMembershipDialog)
+        
 
         self.maintenanceTW = self.maintenanceTableWidget
         self.maintenanceCB = self.maintenanceComboBox
@@ -135,6 +140,10 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
 
     def openRemoveGroupDialog(self):
         dialog = removeDialogueWindowGroup.Group()
+        dialog.exec()
+        
+    def openRemoveMembershipDialog(self):
+        dialog = removeDialogueWindowMembership.Membership()
         dialog.exec()
 
     def openAddMPartyDialog(self):

--- a/desktopApp/ui/maintenanceTab.ui
+++ b/desktopApp/ui/maintenanceTab.ui
@@ -128,7 +128,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>490</y>
+       <y>520</y>
        <width>130</width>
        <height>23</height>
       </rect>
@@ -229,7 +229,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>520</y>
+       <y>550</y>
        <width>130</width>
        <height>23</height>
       </rect>
@@ -277,6 +277,19 @@
      </property>
      <property name="text">
       <string>Lisää</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="maintenanceRemoveMembershipPushButton">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>490</y>
+       <width>130</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Poista jäsenyys...</string>
      </property>
     </widget>
    </widget>

--- a/desktopApp/ui/removeMembershipDialog.ui
+++ b/desktopApp/ui/removeMembershipDialog.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>388</width>
+    <height>135</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>130</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Poistettava jäsenyys</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="removeMembershipComboBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>40</y>
+     <width>340</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="removeMembershipCancelPushButton">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>80</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Peruuta</string>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="removeMembershipPushButton">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>80</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Poista</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Created dialog window for deleting a membership from db and added a button to the maintenance tab for opening it.

Currently in the dialog window the action of choosing the membership to delete is done via combo box showing the name of the member and group and the share multiplier of the membership. If you have any suggestions for that please leave a comment to the Pull Request.