### PR TITLE
87 make dialog for removing a shot

### DIFF
--- a/desktopApp/dialogs/removeDialogues/Shot.py
+++ b/desktopApp/dialogs/removeDialogues/Shot.py
@@ -1,0 +1,85 @@
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import QDialog, QComboBox, QLabel, QPushButton
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame, SuccessfulOperationDialog
+import pgModule as pgModule
+import prepareData as prepareData
+from dialogs.messageModule import PopupMessages as msg
+
+class Shot(DialogFrame):
+    def __init__(self):
+        super().__init__()
+        
+        loadUi("ui/removeShotDialog.ui", self)
+        
+        self.setWindowTitle('Poista kaato')
+        
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+        
+        # Elements
+        self.removeShotCB = self.removeShotComboBox
+        
+        self.removeShotPushBtn = self.removeShotPushButton
+        self.removeShotPushBtn.clicked.connect(self.removeShot) # Signal
+        self.removeShotCancelPushBtn = self.removeShotCancelPushButton
+        self.removeShotCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+        
+        # Populate the shot combo box
+        self.populateRemoveShotDialog()
+        
+    def populateRemoveShotDialog(self):
+        databaseOperation = pgModule.DatabaseOperation()
+        databaseOperation.getAllRowsFromTable(
+            self.connectionArguments, 'public.kaatoluettelo_indeksilla')
+        if databaseOperation.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation.errorMessage,
+                databaseOperation.detailedMessage
+                )
+        else:
+            # Process the data to be shown in the combo box
+            
+            results = databaseOperation.resultSet
+            newResults = []
+            
+            # Read colums 0, 1, 2, 3, 4, 5, 6, 7, 9 from each row in the result set
+            # and generate a string from them to be viewed in the combo box
+            for row in results:
+                newResults.append((f"ID: {row[9]} | {row[1]} | {row[2]} | {row[3]} | {row[4]} | {row[5]} | {row[6]} | {row[7]}", row[9]))
+                
+            databaseOperation.resultSet = newResults
+            
+            self.shotIdList = prepareData.prepareComboBox(
+                databaseOperation, self.removeShotCB, 0, 1)
+        
+    def removeShot(self):
+        try:
+            shotChosenItemIx = self.removeShotCB.currentIndex()
+            shotId = self.shotIdList[shotChosenItemIx]
+            
+            table = 'public.kaato'
+            limit = f"public.kaato.kaato_id = {shotId}"
+        except Exception:
+            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
+        
+        databaseOperation = pgModule.DatabaseOperation()
+        databaseOperation.deleteFromTable(self.connectionArguments, table, limit)
+        if databaseOperation.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation.errorMessage,
+                databaseOperation.detailedMessage
+                )
+        else:
+            msg().successMessage('Kaato poistettu')
+            self.populateRemoveShotDialog()
+    
+    def closeDialog(self):
+        self.close()

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -7,6 +7,7 @@ import prepareData
 
 import dialogs.dialogueWindow as dialogueWindow
 import dialogs.editShotDialog as editShotDialog
+import dialogs.removeDialogues.Shot as removeShotDialog
 
 
 class Ui_killTabWidget(QScrollArea, QWidget):
@@ -44,6 +45,9 @@ class Ui_killTabWidget(QScrollArea, QWidget):
 
         self.editShotsPushBtn = self.editShotsPushButton
         self.editShotsPushBtn.clicked.connect(self.openEditShotDialog) # Signal
+        
+        self.removeShotsPB = self.removeShotsPushButton
+        self.removeShotsPB.clicked.connect(self.opeRemoveShotDialog) # Signal
 
         self.shotLicenseYearCB = self.licenseYearComboBox
         #print(f"valinta:'{self.shotLicenseYearCB.currentText()}'")
@@ -353,4 +357,8 @@ class Ui_killTabWidget(QScrollArea, QWidget):
 
     def openEditShotDialog(self):
         dialog = editShotDialog.EditShot()
+        dialog.exec()
+        
+    def opeRemoveShotDialog(self):
+        dialog = removeShotDialog.Shot()
         dialog.exec()

--- a/desktopApp/ui/killTab.ui
+++ b/desktopApp/ui/killTab.ui
@@ -461,6 +461,19 @@
       <string>Käytön osuus</string>
      </property>
     </widget>
+    <widget class="QPushButton" name="removeShotsPushButton">
+     <property name="geometry">
+      <rect>
+       <x>580</x>
+       <y>480</y>
+       <width>130</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Poista kaato...</string>
+     </property>
+    </widget>
    </widget>
   </widget>
  </widget>

--- a/desktopApp/ui/removeShotDialog.ui
+++ b/desktopApp/ui/removeShotDialog.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>139</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QPushButton" name="removeShotCancelPushButton">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>80</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Peruuta</string>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="removeShotComboBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>40</y>
+     <width>340</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>130</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Poistettava kaato</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="removeShotPushButton">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>80</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Poista</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Added button to shot(/kill) tab that opens a dialog window for deleting row from the db. In the dialog window the shot to be removed is selected from a combo box that shows the following info of the kill:
id | shooter | date | location | animal | age group | sex | weight 

**NOTE!**: For the feature work properly, the migrations [**alter_table_jakotapahtuma**](https://github.com/eeroleppalehto/Jahtirekisteri/blob/development/database/migrations/2023-09-18/alter_table_jakotapahtuma.sql) and [**alter_table_kaadonkasittely**](https://github.com/eeroleppalehto/Jahtirekisteri/blob/development/database/migrations/2023-09-18/alter_table_kaadonkasittely.sql) need to be run in your database. Without it the **kaadon_kasittely**s and **jakotapahtuma**s relating to the deleted shot won't be removed from the database. 