### PR TITLE
79 make dialog for editing a share

### DIFF
--- a/database/migrations/2023-09-21/create_view_jakotapahtuma_ryhman_nimella.sql
+++ b/database/migrations/2023-09-21/create_view_jakotapahtuma_ryhman_nimella.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW public.jakotapahtuma_ryhman_nimella
+ AS
+ SELECT jakotapahtuma.tapahtuma_id AS "Jako",
+    jakotapahtuma.paiva AS pvm,
+    jakotapahtuma.ryhma_id AS "Ryhmä ID",
+    jakoryhma.ryhman_nimi AS "Ryhmän Nimi",
+    jakotapahtuma.osnimitys AS "Ruhonosa",
+    jakotapahtuma.kaadon_kasittely_id AS "Kaadon kasittely ID",
+    jakotapahtuma.maara AS "Paino",
+    kaadon_kasittely.kaato_id AS "Kaato ID"
+   FROM jakotapahtuma
+     JOIN jakoryhma ON jakoryhma.ryhma_id = jakotapahtuma.ryhma_id
+     JOIN kaadon_kasittely ON kaadon_kasittely.kaadon_kasittely_id = jakotapahtuma.kaadon_kasittely_id;

--- a/desktopApp/dialogs/editDialogues/Share.py
+++ b/desktopApp/dialogs/editDialogues/Share.py
@@ -91,3 +91,42 @@ class Share(DialogFrame):
         else:
             self.shareGroupsIdList = prepareData.prepareComboBox(databaseOperation3, self.editShareGroupCB, 2, 0)
     
+    def onTableClick(self, item: QTableWidgetItem):
+        """Method for handling the click event on the table
+
+        Args:
+            item (QTableWidgetItem): Item clicked in the table
+        """
+        selectedRow = item.row()
+        self.itemToPopulate = {
+            "tapahtuma_id": int(self.editShareTW.item(selectedRow, 0).text()),
+            "paiva": self.editShareTW.item(selectedRow, 1).text(),
+            "ryhma_id": int(self.editShareTW.item(selectedRow, 2).text()),
+            "ryhma_nimi": self.editShareTW.item(selectedRow, 3).text(),
+            "osnimitys": self.editShareTW.item(selectedRow, 4).text(),
+            "kaadon_kasittely_id": int(self.editShareTW.item(selectedRow, 5).text()),
+            "maara": float(self.editShareTW.item(selectedRow, 6).text()),
+            "kaato_id": int(self.editShareTW.item(selectedRow, 7).text())
+        }
+        self.editSharePopulatePushBtn.setEnabled(True)
+    
+    def populateFields(self):
+        """ Method for populating the fields in the edit share dialog once the populate button is clicked
+        """
+        try:
+            self.editShareDE.setDate(QDate.fromString(self.itemToPopulate["paiva"], "yyyy-MM-dd"))
+            self.editSharePortionCB.setCurrentIndex(self.sharePortions.index(self.itemToPopulate["osnimitys"]))
+            self.editShareGroupCB.setCurrentIndex(self.shareGroupsIdList.index(self.itemToPopulate["ryhma_id"]))
+            
+            self.selectedShareDict = self.itemToPopulate
+            self.editSharePopulatePushBtn.setEnabled(False)
+            self.editShareSavePushBtn.setEnabled(True)
+            self.editShareChosenLbl.setText(f"Valittu Jako ID: {self.itemToPopulate['tapahtuma_id']}, Kaato ID: {self.itemToPopulate['kaato_id']}")
+            
+        except Exception as e:
+            self.alert(
+                'Vakava virhe',
+                'Kenttien täyttö epäonnistui',
+                str(e),
+                str(e)
+            )

--- a/desktopApp/dialogs/editDialogues/Share.py
+++ b/desktopApp/dialogs/editDialogues/Share.py
@@ -48,3 +48,46 @@ class Share(DialogFrame):
         self.editSharePopulatePushBtn.setEnabled(False)
         
         self.populateEditShareDialog()
+    
+    
+    def populateEditShareDialog(self):
+        """Method for populating the edit share dialog with data from the database
+        """
+        databaseOperation1 = pgModule.DatabaseOperation()
+        databaseOperation1.getAllRowsFromTable(self.connectionArguments, 'public.jakotapahtuma_ryhman_nimella')
+        if databaseOperation1.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation1.errorMessage,
+                databaseOperation1.detailedMessage
+                )
+        else:
+            prepareData.prepareTable(databaseOperation1, self.editShareTW)
+            self.editShareTW.setColumnHidden(2, True)
+            self.editShareTW.setColumnHidden(5, True)
+            
+        databaseOperation2 = pgModule.DatabaseOperation()
+        databaseOperation2.getAllRowsFromTable(self.connectionArguments, 'public.ruhonosa')
+        if databaseOperation2.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation2.errorMessage,
+                databaseOperation2.detailedMessage
+                )
+        else:
+            self.sharePortions = prepareData.prepareComboBox(databaseOperation2, self.editSharePortionCB, 0, 0)
+            
+        databaseOperation3 = pgModule.DatabaseOperation()
+        databaseOperation3.getAllRowsFromTable(self.connectionArguments, 'public.jakoryhma')
+        if databaseOperation3.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation3.errorMessage,
+                databaseOperation3.detailedMessage
+                )
+        else:
+            self.shareGroupsIdList = prepareData.prepareComboBox(databaseOperation3, self.editShareGroupCB, 2, 0)
+    

--- a/desktopApp/dialogs/editDialogues/Share.py
+++ b/desktopApp/dialogs/editDialogues/Share.py
@@ -1,0 +1,50 @@
+# LIBRARIES AND MODULES
+# ---------------------
+import sys
+# Add parent directory to the path
+sys.path.append('../desktopApp')
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import (QDialog, QLabel, QPushButton,
+                             QComboBox, QTableWidget, QDateEdit,
+                             QMainWindow, QApplication, QTableWidgetItem)
+from PyQt5.uic import loadUi
+from dialogs.dialogueWindow import DialogFrame
+import pgModule as pgModule
+import prepareData as prepareData
+from datetime import date
+
+from dialogs.messageModule import PopupMessages as msg
+
+class Share(DialogFrame):
+    """Dialog window for editing existing shares"""
+    def __init__(self):
+        super().__init__()
+        
+        loadUi("ui/editShareDialog.ui", self)
+        
+        databaseOperationConnections = pgModule.DatabaseOperation()
+        self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
+        
+        self.setWindowTitle('Muokkaa lihanjakoa')
+        
+        # Elements
+        self.editShareTW: QTableWidget = self.editShareTableWidget
+        self.editShareTW.itemClicked.connect(self.onTableClick)
+        self.editShareDE: QDateEdit = self.editShareDateEdit
+        self.editSharePortionCB: QComboBox = self.editSharePortionComboBox
+        self.editShareGroupCB: QComboBox = self.editShareGroupComboBox
+        # Label for showing the chosen share and kill id
+        self.editShareChosenLbl: QLabel = self.editShareChosenLabel
+        
+        self.editShareSavePushBtn: QPushButton = self.editShareSavePushButton
+        self.editShareSavePushBtn.clicked.connect(self.saveEdit) # Signal
+        self.editShareCancelPushBtn: QPushButton = self.editShareCancelPushButton
+        self.editShareCancelPushBtn.clicked.connect(self.closeDialog) # Signal
+        self.editSharePopulatePushBtn: QPushButton = self.editSharePopulatePushButton
+        self.editSharePopulatePushBtn.clicked.connect(self.populateFields) # Signal
+        
+        # Set initial state of the buttons to false
+        self.editShareSavePushBtn.setEnabled(False)
+        self.editSharePopulatePushBtn.setEnabled(False)
+        
+        self.populateEditShareDialog()

--- a/desktopApp/tabs/shareTabWidget.py
+++ b/desktopApp/tabs/shareTabWidget.py
@@ -1,5 +1,5 @@
 
-from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox
+from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox, QPushButton
 from PyQt5 import QtCore
 from PyQt5.uic import loadUi
 from datetime import date
@@ -9,6 +9,7 @@ import figures
 import party
 
 import dialogs.dialogueWindow as dialogueWindow
+import dialogs.editDialogues.Share as editShareDialog
 
 
 class Ui_shareTabWidget(QScrollArea, QWidget):
@@ -24,7 +25,10 @@ class Ui_shareTabWidget(QScrollArea, QWidget):
         self.shareGroupCB = self.groupComboBox
         self.shareSavePushBtn = self.shareSavePushButton
         self.shareSavePushBtn.clicked.connect(self.saveShare) # Signal
+        self.shareEditPushBtn: QPushButton = self.shareEditPushButton
+        self.shareEditPushBtn.clicked.connect(self.openEditShareDialog) # Signal
         self.sharedPortionsTW = self.shareSharedPortionsTableWidget
+        
 
         self.shareSankeyWebView = self.shareSankeyWebEngineView
 
@@ -256,6 +260,10 @@ class Ui_shareTabWidget(QScrollArea, QWidget):
         selectedRow = item.row()
         self.shotUsageId = self.shareKillsTW.item(selectedRow, 10).text()
         self.shotWeight = float(self.shareKillsTW.item(selectedRow, 9).text())
+        
+    def openEditShareDialog(self):
+        dialog = editShareDialog.Share()
+        dialog.exec()
 
 
     def openSettingsDialog(self):

--- a/desktopApp/ui/editShareDialog.ui
+++ b/desktopApp/ui/editShareDialog.ui
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>833</width>
+    <height>473</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QTableWidget" name="editShareTableWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>40</y>
+     <width>761</width>
+     <height>211</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QDateEdit" name="editShareDateEdit">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>310</y>
+     <width>110</width>
+     <height>26</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="editSharePortionComboBox">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>310</y>
+     <width>120</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="editShareGroupComboBox">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>310</y>
+     <width>130</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>290</y>
+     <width>100</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Jakopäivä</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="editShareSavePushButton">
+   <property name="geometry">
+    <rect>
+     <x>100</x>
+     <y>350</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Tallenna</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="editShareCancelPushButton">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>350</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Peruuta</string>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="editSharePopulatePushButton">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>260</y>
+     <width>80</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Täytä</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>290</y>
+     <width>120</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Ruhonosa</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>290</y>
+     <width>100</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Jakoryhmä</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>120</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>12</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Jaot</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="editShareChosenLabel">
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>264</y>
+     <width>291</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Ei valittua jakoa</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/desktopApp/ui/shareTab.ui
+++ b/desktopApp/ui/shareTab.ui
@@ -203,6 +203,19 @@
       <string>Jaetut ruhon osat</string>
      </property>
     </widget>
+    <widget class="QPushButton" name="shareEditPushButton">
+     <property name="geometry">
+      <rect>
+       <x>790</x>
+       <y>250</y>
+       <width>140</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Muokkaa jakoja...</string>
+     </property>
+    </widget>
    </widget>
   </widget>
  </widget>


### PR DESCRIPTION
Added button to share tab that open a dialog window for editing shares. Also created view `jakotapahtuma_ryhman_nimella` to be shown in the **QTableWidget** in the dialog.


**NOTE!** For the dialog to work, your database needs the `jakotapahtuma_ryhman_nimella`-view to be saved as the TableWidget is populated with that views data.