### PR TITLE
63 look into how to add sort functionality to tablewidgets in desktop app

### DIFF
--- a/database/migrations/2023-09-26/alter_view_kaatoluettelo.sql
+++ b/database/migrations/2023-09-26/alter_view_kaatoluettelo.sql
@@ -1,0 +1,18 @@
+-- Added column "kaato_id" to table "kaato" for sorting the table based on it in desktop application
+
+CREATE OR REPLACE VIEW public.kaatoluettelo
+ AS
+ SELECT (jasen.sukunimi::text || ' '::text) || jasen.etunimi::text AS "Kaataja",
+    kaato.kaatopaiva AS "Kaatopäivä",
+    kaato.paikka_teksti AS "Paikka",
+    kaato.elaimen_nimi AS "Eläin",
+    kaato.ikaluokka AS "Ikäluokka",
+    kaato.sukupuoli AS "Sukupuoli",
+    kaato.ruhopaino AS "Paino",
+    kaato.kaato_id AS "Kaato ID",
+    count(kaadon_kasittely.kaato_id) AS "Käsittelyt"
+   FROM kaato
+     JOIN jasen ON jasen.jasen_id = kaato.jasen_id
+     JOIN kaadon_kasittely ON kaato.kaato_id = kaadon_kasittely.kaato_id
+  GROUP BY ((jasen.sukunimi::text || ' '::text) || jasen.etunimi::text), kaato.kaatopaiva, kaato.paikka_teksti, kaato.elaimen_nimi, kaato.ikaluokka, kaato.sukupuoli, kaato.ruhopaino, kaato.kaato_id
+  ORDER BY kaato.kaato_id DESC;

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -49,6 +49,8 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             'Paino \u2191',
             ]
         self.shotSortShotsCB.addItems(shotSortOptions)
+        self.shotSortShotsCB.currentIndexChanged.connect(self.sortShots) # Signal
+
         self.shotUsageCB = self.usageComboBox
         self.shotUsagePortionSB = self.usagePortionSpinBox
         self.shotUsagePortionSB.valueChanged.connect(self.calculateUsage2Value) # Signal
@@ -218,6 +220,8 @@ class Ui_killTabWidget(QScrollArea, QWidget):
                 'Ei löytynyt vuotta, jolta hakea lupatietoja',
                 'Could not find year to fetch licence data from, try adding a license in the license page first'
                 )
+        self.sortShots()        
+    
             
         
     def populateLicenceCB(self):
@@ -366,6 +370,46 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         value = self.shotUsagePortionSB.value()
         self.shotUsage2PortionSB.setValue(100 - value)
 
+    def sortShots(self):
+        """Sorts the shot table based on the selected combo box value
+            the /u2191 and /u2193 are unicode characters for up and down arrows
+        """
+        # Check the current text of the combo box and sort the table based on that
+        if self.shotSortShotsCB.currentText() == 'Kaataja \u2191':
+            self.shotKillsTW.sortItems(0, order=Qt.DescendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Kaataja \u2193':
+            self.shotKillsTW.sortItems(0, order=Qt.AscendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Kaatopäivä \u2191':
+            self.shotKillsTW.sortItems(1, order=Qt.AscendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Kaatopäivä \u2193':
+            self.shotKillsTW.sortItems(1, order=Qt.DescendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Paikka \u2191':
+            self.shotKillsTW.sortItems(2, order=Qt.DescendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Paikka \u2193':
+            self.shotKillsTW.sortItems(2, order=Qt.AscendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Eläin \u2191':
+            self.shotKillsTW.sortItems(3, order=Qt.DescendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Eläin \u2193':
+            self.shotKillsTW.sortItems(3, order=Qt.AscendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Ikäluokka \u2191':
+            self.shotKillsTW.sortItems(4, order=Qt.DescendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Ikäluokka \u2193':
+            self.shotKillsTW.sortItems(4, order=Qt.AscendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Sukupuoli \u2191':
+            self.shotKillsTW.sortItems(5, order=Qt.DescendingOrder)
+        elif self.shotSortShotsCB.currentText() == 'Sukupuoli \u2193':
+            self.shotKillsTW.sortItems(5, order=Qt.AscendingOrder)
+            
+        elif self.shotSortShotsCB.currentText() == 'Paino \u2191':
+            self.sortNumericCells(6, False)
+        elif self.shotSortShotsCB.currentText() == 'Paino \u2193':
+            self.sortNumericCells(6, True)
+    
     #SIGNALS
     def openSettingsDialog(self):
         dialog = dialogueWindow.SaveDBSettingsDialog()

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -1,5 +1,6 @@
 
-from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox
+from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox, QComboBox
+from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
 from datetime import date
 import pgModule
@@ -28,7 +29,26 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         self.shotSavePushBtn.clicked.connect(self.saveShotAndUsage) # Signal
         self.shotKillsTW = self.killsKillsTableWidget
         self.shotLicenseTW = self.shotLicenseTableWidget
-
+        
+        # Combo boxes for sorting the shot table
+        self.shotSortShotsCB: QComboBox = self.sortKillsComboBox
+        shotSortOptions = [
+            'Kaataja \u2193',
+            'Kaataja \u2191',
+            'Kaatopäivä \u2193',
+            'Kaatopäivä \u2191',
+            'Paikka \u2193',
+            'Paikka \u2191',
+            'Eläin \u2193',
+            'Eläin \u2191',
+            'Ikäluokka \u2193',
+            'Ikäluokka \u2191',
+            'Sukupuoli \u2193',
+            'Sukupuoli \u2191',
+            'Paino \u2193',
+            'Paino \u2191',
+            ]
+        self.shotSortShotsCB.addItems(shotSortOptions)
         self.shotUsageCB = self.usageComboBox
         self.shotUsagePortionSB = self.usagePortionSpinBox
         self.shotUsagePortionSB.valueChanged.connect(self.calculateUsage2Value) # Signal

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -47,6 +47,8 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             'Sukupuoli \u2191',
             'Paino \u2193',
             'Paino \u2191',
+            'Kaato ID \u2193',
+            'Kaato ID \u2191'
             ]
         self.shotSortShotsCB.addItems(shotSortOptions)
         self.shotSortShotsCB.currentIndexChanged.connect(self.sortShots) # Signal
@@ -410,6 +412,11 @@ class Ui_killTabWidget(QScrollArea, QWidget):
             self.sortNumericCells(6, False)
         elif self.shotSortShotsCB.currentText() == 'Paino \u2193':
             self.sortNumericCells(6, True)
+            
+        elif self.shotSortShotsCB.currentText() == 'Kaato ID \u2191':
+            self.sortNumericCells(7, False)
+        elif self.shotSortShotsCB.currentText() == 'Kaato ID \u2193':
+            self.sortNumericCells(7, True)
     
     def sortNumericCells(self, columnNumber: int, reverse: bool):
         """

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -68,7 +68,6 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         self.editShotsPushBtn.clicked.connect(self.openEditShotDialog) # Signal
 
         self.shotLicenseYearCB = self.licenseYearComboBox
-        #print(f"valinta:'{self.shotLicenseYearCB.currentText()}'")
 
         # Read database connection arguments from the settings file
         try:

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -1,5 +1,5 @@
 
-from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox, QComboBox
+from PyQt5.QtWidgets import QWidget, QScrollArea, QMessageBox, QComboBox, QDateEdit, QTableWidget, QSpinBox, QCheckBox, QPlainTextEdit, QLineEdit, QPushButton, QGridLayout
 from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
 from datetime import date
@@ -17,18 +17,18 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         
         self.currentDate = date.today()
         
-        self.shotByCB = self.shotByComboBox
-        self.shotDateDE = self.shotDateEdit
-        self.shotLocationLE = self.locationLineEdit
-        self.shotAnimalCB = self.animalComboBox
-        self.shotAgeGroupCB = self.ageGroupComboBox
-        self.shotGenderCB = self.genderComboBox
-        self.shotWeightLE = self.weightLineEdit
-        self.shotAddInfoTE = self.additionalInfoTextEdit
-        self.shotSavePushBtn = self.saveShotPushButton
+        self.shotByCB: QComboBox = self.shotByComboBox
+        self.shotDateDE: QDateEdit = self.shotDateEdit
+        self.shotLocationLE: QLineEdit = self.locationLineEdit
+        self.shotAnimalCB: QComboBox = self.animalComboBox
+        self.shotAgeGroupCB: QComboBox = self.ageGroupComboBox
+        self.shotGenderCB: QComboBox = self.genderComboBox
+        self.shotWeightLE: QLineEdit = self.weightLineEdit
+        self.shotAddInfoTE: QPlainTextEdit = self.additionalInfoTextEdit
+        self.shotSavePushBtn: QPushButton = self.saveShotPushButton
         self.shotSavePushBtn.clicked.connect(self.saveShotAndUsage) # Signal
-        self.shotKillsTW = self.killsKillsTableWidget
-        self.shotLicenseTW = self.shotLicenseTableWidget
+        self.shotKillsTW: QTableWidget = self.killsKillsTableWidget
+        self.shotLicenseTW: QTableWidget = self.shotLicenseTableWidget
         
         # Combo boxes for sorting the shot table
         self.shotSortShotsCB: QComboBox = self.sortKillsComboBox
@@ -51,23 +51,23 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         self.shotSortShotsCB.addItems(shotSortOptions)
         self.shotSortShotsCB.currentIndexChanged.connect(self.sortShots) # Signal
 
-        self.shotUsageCB = self.usageComboBox
-        self.shotUsagePortionSB = self.usagePortionSpinBox
+        self.shotUsageCB: QComboBox = self.usageComboBox
+        self.shotUsagePortionSB: QSpinBox = self.usagePortionSpinBox
         self.shotUsagePortionSB.valueChanged.connect(self.calculateUsage2Value) # Signal
 
-        self.shotUsage2CheckB = self.usage2CheckBox
+        self.shotUsage2CheckB: QCheckBox = self.usage2CheckBox
         self.shotUsage2CheckB.stateChanged.connect(self.toggleUsage2) # Signal
 
-        self.shotUsage2CB = self.usage2ComboBox
+        self.shotUsage2CB: QComboBox = self.usage2ComboBox
         self.shotUsage2CB.setEnabled(False)
 
-        self.shotUsage2PortionSB = self.usage2PortionSpinBox
+        self.shotUsage2PortionSB: QSpinBox = self.usage2PortionSpinBox
         self.shotUsage2PortionSB.setEnabled(False)
 
-        self.editShotsPushBtn = self.editShotsPushButton
+        self.editShotsPushBtn: QPushButton = self.editShotsPushButton
         self.editShotsPushBtn.clicked.connect(self.openEditShotDialog) # Signal
 
-        self.shotLicenseYearCB = self.licenseYearComboBox
+        self.shotLicenseYearCB: QComboBox = self.licenseYearComboBox
 
         # Read database connection arguments from the settings file
         try:

--- a/desktopApp/tabs/killTabWidget.py
+++ b/desktopApp/tabs/killTabWidget.py
@@ -106,6 +106,7 @@ class Ui_killTabWidget(QScrollArea, QWidget):
     def populateKillPage(self):
         # Set default date to current date
         self.shotDateDE.setDate(self.currentDate)
+        
         # Read data from view kaatoluettelo
         databaseOperation1 = pgModule.DatabaseOperation()
         databaseOperation1.getAllRowsFromTable(
@@ -118,6 +119,7 @@ class Ui_killTabWidget(QScrollArea, QWidget):
                 databaseOperation1.detailedMessage
                 )
         else:
+            self.shotKillData = databaseOperation1
             prepareData.prepareTable(databaseOperation1, self.shotKillsTW)
 
         # Read data from view nimivalinta
@@ -410,6 +412,23 @@ class Ui_killTabWidget(QScrollArea, QWidget):
         elif self.shotSortShotsCB.currentText() == 'Paino \u2193':
             self.sortNumericCells(6, True)
     
+    def sortNumericCells(self, columnNumber: int, reverse: bool):
+        """
+            As the sortItems() method does not work with numeric values,
+            we need to sort the data manually
+            
+            Args:
+                columnNumber (int): the column number of the table to sort
+                reverse (bool): reverse the order of the sort if True
+        """
+        
+        self.shotKillData.resultSet.sort(reverse=reverse, key=lambda x: float(x[columnNumber]))
+        
+        # Mount the data back to the TableWidget
+        prepareData.prepareTable(self.shotKillData, self.shotKillsTW)
+        
+        
+
     #SIGNALS
     def openSettingsDialog(self):
         dialog = dialogueWindow.SaveDBSettingsDialog()

--- a/desktopApp/ui/killTab.ui
+++ b/desktopApp/ui/killTab.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>861</width>
-    <height>771</height>
+    <height>792</height>
    </rect>
   </property>
   <widget class="QScrollArea" name="scrollArea">
@@ -149,7 +149,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>260</y>
+       <y>280</y>
        <width>841</width>
        <height>211</height>
       </rect>
@@ -228,7 +228,7 @@
      <property name="geometry">
       <rect>
        <x>720</x>
-       <y>480</y>
+       <y>500</y>
        <width>130</width>
        <height>23</height>
       </rect>
@@ -254,7 +254,7 @@
      <property name="geometry">
       <rect>
        <x>380</x>
-       <y>530</y>
+       <y>550</y>
        <width>60</width>
        <height>20</height>
       </rect>
@@ -360,7 +360,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>560</y>
+       <y>580</y>
        <width>521</width>
        <height>181</height>
       </rect>
@@ -383,7 +383,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>530</y>
+       <y>550</y>
        <width>110</width>
        <height>20</height>
       </rect>
@@ -401,7 +401,7 @@
      <property name="geometry">
       <rect>
        <x>450</x>
-       <y>530</y>
+       <y>550</y>
        <width>80</width>
        <height>22</height>
       </rect>
@@ -411,7 +411,7 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>230</y>
+       <y>250</y>
        <width>80</width>
        <height>20</height>
       </rect>
@@ -459,6 +459,29 @@
      </property>
      <property name="text">
       <string>Käytön osuus</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="sortKillsComboBox">
+     <property name="geometry">
+      <rect>
+       <x>720</x>
+       <y>240</y>
+       <width>130</width>
+       <height>26</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label">
+     <property name="geometry">
+      <rect>
+       <x>720</x>
+       <y>217</y>
+       <width>130</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Lajittele</string>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
To test out the sorting feature, the shot table in shot tab was used. Sorting was added to it by adding a combo box with the options for sorting and when the item in combo box is changed it sends a signal to **sortShots**-method which detects the current text in the combo box and based on that uses the [**sortItems** ](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QTableWidget.html#PySide2.QtWidgets.PySide2.QtWidgets.QTableWidget.sortItems)-method from QTableWidget. For numeric columns I had to manually sort them as the previous method sorted the cells as text and not numbers. The code for that can be found under the **sortNumericCells**-method.

**Note!** I added `kaato_id` to view `kaatoluettelo` for sorting the table based on it. For those options to work properly, add the SQL script `alter_view_kaatoluettelo.sql` to your database.