### PR TITLE
96 add a way to share a kill to member of the

### DIFF
--- a/database/backups/2023-10-05/2023-10-05_backup.sql
+++ b/database/backups/2023-10-05/2023-10-05_backup.sql
@@ -1,0 +1,2030 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 14.8
+-- Dumped by pg_dump version 14.8
+
+-- Started on 2023-10-05 00:09:02
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- TOC entry 272 (class 1255 OID 16673)
+-- Name: get_used_licences(integer); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.get_used_licences(license_year integer) RETURNS TABLE("Lupia jäljellä" bigint, "Lupia jäljellä(%)" integer, "Eläin" character varying, "Sukupuoli" character varying, "Ikäluokka" character varying)
+    LANGUAGE sql
+    AS $$SELECT lupa.maara - COUNT(kaato.kaato_id) AS "Lupia jäljellä",
+    ROUND((100 * (lupa.maara - COUNT(kaato.kaato_id)))::double precision / lupa.maara::double precision)::integer AS "Lupia jäljellä(%)",
+    lupa.elaimen_nimi AS "Eläin",
+    lupa.sukupuoli AS "Sukupuoli",
+    lupa.ikaluokka AS "Ikäluokka"
+FROM lupa
+LEFT JOIN kaato ON lupa.sukupuoli::text = kaato.sukupuoli::text
+    AND lupa.ikaluokka::text = kaato.ikaluokka::text
+    AND kaato.elaimen_nimi::text = lupa.elaimen_nimi::text
+    AND kaato.kaatopaiva BETWEEN (license_year::text || '-07-1')::date AND ((license_year + 1)::text || '-06-30')::date
+WHERE lupa.lupavuosi = license_year::text
+GROUP BY lupa.elaimen_nimi, lupa.maara, lupa.sukupuoli, lupa.ikaluokka;$$;
+
+
+ALTER FUNCTION public.get_used_licences(license_year integer) OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- TOC entry 209 (class 1259 OID 16674)
+-- Name: aikuinenvasa; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.aikuinenvasa (
+    ikaluokka character varying(20) NOT NULL
+);
+
+
+ALTER TABLE public.aikuinenvasa OWNER TO postgres;
+
+--
+-- TOC entry 210 (class 1259 OID 16677)
+-- Name: elain; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.elain (
+    elaimen_nimi character varying(20) NOT NULL
+);
+
+
+ALTER TABLE public.elain OWNER TO postgres;
+
+--
+-- TOC entry 211 (class 1259 OID 16680)
+-- Name: jakoryhma; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jakoryhma (
+    ryhma_id integer NOT NULL,
+    seurue_id integer NOT NULL,
+    ryhman_nimi character varying(50) NOT NULL
+);
+
+
+ALTER TABLE public.jakoryhma OWNER TO postgres;
+
+--
+-- TOC entry 3599 (class 0 OID 0)
+-- Dependencies: 211
+-- Name: TABLE jakoryhma; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.jakoryhma IS 'Ryhmä, jolle lihaa jaetaan';
+
+
+--
+-- TOC entry 212 (class 1259 OID 16683)
+-- Name: jakotapahtuma; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jakotapahtuma (
+    tapahtuma_id integer NOT NULL,
+    paiva date NOT NULL,
+    ryhma_id integer NOT NULL,
+    osnimitys character varying(20) NOT NULL,
+    kaadon_kasittely_id integer NOT NULL,
+    maara real NOT NULL
+);
+
+
+ALTER TABLE public.jakotapahtuma OWNER TO postgres;
+
+--
+-- TOC entry 3600 (class 0 OID 0)
+-- Dependencies: 212
+-- Name: COLUMN jakotapahtuma.maara; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.jakotapahtuma.maara IS 'Jaettu lihamäärä kiloina';
+
+
+--
+-- TOC entry 213 (class 1259 OID 16686)
+-- Name: jaetut_lihat; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jaetut_lihat AS
+ SELECT jakoryhma.ryhman_nimi AS "Ryhmän Nimi",
+    sum(jakotapahtuma.maara) AS "Kg Yhteensä"
+   FROM (public.jakoryhma
+     LEFT JOIN public.jakotapahtuma ON ((jakotapahtuma.ryhma_id = jakoryhma.ryhma_id)))
+  GROUP BY jakoryhma.ryhman_nimi
+  ORDER BY jakoryhma.ryhman_nimi;
+
+
+ALTER TABLE public.jaetut_lihat OWNER TO postgres;
+
+--
+-- TOC entry 214 (class 1259 OID 16690)
+-- Name: kaadon_kasittely; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.kaadon_kasittely (
+    kaadon_kasittely_id integer NOT NULL,
+    kasittelyid integer NOT NULL,
+    kaato_id integer NOT NULL,
+    kasittely_maara integer NOT NULL
+);
+
+
+ALTER TABLE public.kaadon_kasittely OWNER TO postgres;
+
+--
+-- TOC entry 215 (class 1259 OID 16693)
+-- Name: kaato; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.kaato (
+    kaato_id integer NOT NULL,
+    jasen_id integer NOT NULL,
+    kaatopaiva date NOT NULL,
+    ruhopaino real NOT NULL,
+    paikka_teksti character varying(100) NOT NULL,
+    paikka_koordinaatti character varying(100),
+    elaimen_nimi character varying(20) NOT NULL,
+    sukupuoli character varying(20) NOT NULL,
+    ikaluokka character varying(20) NOT NULL,
+    lisatieto character varying(255)
+);
+
+
+ALTER TABLE public.kaato OWNER TO postgres;
+
+--
+-- TOC entry 3601 (class 0 OID 0)
+-- Dependencies: 215
+-- Name: TABLE kaato; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.kaato IS 'Ampumatapahtuman tiedot';
+
+
+--
+-- TOC entry 3602 (class 0 OID 0)
+-- Dependencies: 215
+-- Name: COLUMN kaato.ruhopaino; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.kaato.ruhopaino IS 'paino kiloina';
+
+
+--
+-- TOC entry 3603 (class 0 OID 0)
+-- Dependencies: 215
+-- Name: COLUMN kaato.paikka_koordinaatti; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.kaato.paikka_koordinaatti IS 'Tämän kentän tietotyyppi pitää oikeasti olla geometry (Postgis-tietotyyppi)';
+
+
+--
+-- TOC entry 216 (class 1259 OID 16698)
+-- Name: jaetut_ruhon_osat; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jaetut_ruhon_osat AS
+ SELECT kaato.kaato_id AS "KaatoID",
+    kaato.elaimen_nimi AS "Eläin",
+    jakotapahtuma.osnimitys AS "Ruhon osa",
+    jakotapahtuma.maara AS "Määrä",
+    kaadon_kasittely.kasittely_maara AS "Käsittelyn Määrä"
+   FROM ((public.kaato
+     JOIN public.kaadon_kasittely ON ((kaadon_kasittely.kaato_id = kaato.kaato_id)))
+     JOIN public.jakotapahtuma ON ((jakotapahtuma.kaadon_kasittely_id = kaadon_kasittely.kaadon_kasittely_id)))
+  ORDER BY kaato.kaato_id DESC;
+
+
+ALTER TABLE public.jaetut_ruhon_osat OWNER TO postgres;
+
+--
+-- TOC entry 217 (class 1259 OID 16703)
+-- Name: jakotapahtuma_jasen; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jakotapahtuma_jasen (
+    tapahtuma_jasen_id integer NOT NULL,
+    paiva date NOT NULL,
+    kaadon_kasittely_id integer NOT NULL,
+    osnimitys character varying(20) NOT NULL,
+    maara real NOT NULL,
+    jasenyys_id integer NOT NULL
+);
+
+
+ALTER TABLE public.jakotapahtuma_jasen OWNER TO postgres;
+
+--
+-- TOC entry 3604 (class 0 OID 0)
+-- Dependencies: 217
+-- Name: TABLE jakotapahtuma_jasen; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.jakotapahtuma_jasen IS 'Table for storing shares given straight to members';
+
+
+--
+-- TOC entry 218 (class 1259 OID 16706)
+-- Name: jaetut_ruhon_osat_jasenille; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jaetut_ruhon_osat_jasenille AS
+ SELECT kaato.kaato_id AS "KaatoID",
+    kaato.elaimen_nimi AS "Eläin",
+    jakotapahtuma_jasen.osnimitys AS "Ruhon osa",
+    jakotapahtuma_jasen.maara AS "Määrä",
+    kaadon_kasittely.kasittely_maara AS "Käsittelyn Määrä"
+   FROM ((public.kaato
+     JOIN public.kaadon_kasittely ON ((kaadon_kasittely.kaato_id = kaato.kaato_id)))
+     JOIN public.jakotapahtuma_jasen ON ((jakotapahtuma_jasen.kaadon_kasittely_id = kaadon_kasittely.kaadon_kasittely_id)))
+  ORDER BY kaato.kaato_id DESC;
+
+
+ALTER TABLE public.jaetut_ruhon_osat_jasenille OWNER TO postgres;
+
+--
+-- TOC entry 219 (class 1259 OID 16711)
+-- Name: jasen; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jasen (
+    jasen_id integer NOT NULL,
+    etunimi character varying(50) NOT NULL,
+    sukunimi character varying(50) NOT NULL,
+    jakeluosoite character varying(30) NOT NULL,
+    postinumero character varying(10) NOT NULL,
+    postitoimipaikka character varying(30) NOT NULL,
+    tila character varying(20) DEFAULT 'aktiivinen'::character varying
+);
+
+
+ALTER TABLE public.jasen OWNER TO postgres;
+
+--
+-- TOC entry 3605 (class 0 OID 0)
+-- Dependencies: 219
+-- Name: TABLE jasen; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.jasen IS 'Henkilö joka osallistuu metsästykseen tai lihanjakoon';
+
+
+--
+-- TOC entry 220 (class 1259 OID 16715)
+-- Name: kasittely; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.kasittely (
+    kasittelyid integer NOT NULL,
+    kasittely_teksti character varying(50) NOT NULL
+);
+
+
+ALTER TABLE public.kasittely OWNER TO postgres;
+
+--
+-- TOC entry 221 (class 1259 OID 16718)
+-- Name: jako_kaadot; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jako_kaadot AS
+ SELECT kaadon_kasittely.kaato_id AS "KaatoID",
+    kaadon_kasittely.kasittely_maara AS "Jako Määrä(%)",
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Kaataja",
+    kaato.kaatopaiva AS "kaatopäivä",
+    kaato.paikka_teksti AS "Paikka",
+    kaato.elaimen_nimi AS "Eläin",
+    kaato.ikaluokka AS "Ikäluokka",
+    kaato.sukupuoli AS "Sukupuoli",
+    kasittely.kasittely_teksti AS "Käyttö",
+    kaato.ruhopaino AS "Paino",
+    kaadon_kasittely.kaadon_kasittely_id
+   FROM (((public.jasen
+     JOIN public.kaato ON ((jasen.jasen_id = kaato.jasen_id)))
+     JOIN public.kaadon_kasittely ON ((kaadon_kasittely.kaato_id = kaato.kaato_id)))
+     JOIN public.kasittely ON ((kaadon_kasittely.kasittelyid = kasittely.kasittelyid)))
+  WHERE (kaadon_kasittely.kasittelyid = 2)
+  ORDER BY kaadon_kasittely.kaato_id DESC;
+
+
+ALTER TABLE public.jako_kaadot OWNER TO postgres;
+
+--
+-- TOC entry 222 (class 1259 OID 16723)
+-- Name: jako_kaadot_jasenille; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jako_kaadot_jasenille AS
+ SELECT kaadon_kasittely.kaato_id AS "KaatoID",
+    kaadon_kasittely.kasittely_maara AS "Jako Määrä(%)",
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Kaataja",
+    kaato.kaatopaiva AS "kaatopäivä",
+    kaato.paikka_teksti AS "Paikka",
+    kaato.elaimen_nimi AS "Eläin",
+    kaato.ikaluokka AS "Ikäluokka",
+    kaato.sukupuoli AS "Sukupuoli",
+    kasittely.kasittely_teksti AS "Käyttö",
+    kaato.ruhopaino AS "Paino",
+    kaadon_kasittely.kaadon_kasittely_id
+   FROM (((public.jasen
+     JOIN public.kaato ON ((jasen.jasen_id = kaato.jasen_id)))
+     JOIN public.kaadon_kasittely ON ((kaadon_kasittely.kaato_id = kaato.kaato_id)))
+     JOIN public.kasittely ON ((kaadon_kasittely.kasittelyid = kasittely.kasittelyid)))
+  WHERE (kaadon_kasittely.kasittelyid = 5)
+  ORDER BY kaadon_kasittely.kaato_id DESC;
+
+
+ALTER TABLE public.jako_kaadot_jasenille OWNER TO postgres;
+
+--
+-- TOC entry 223 (class 1259 OID 16728)
+-- Name: jasenyys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.jasenyys (
+    jasenyys_id integer NOT NULL,
+    ryhma_id integer,
+    jasen_id integer NOT NULL,
+    osuus integer NOT NULL,
+    liittyi date NOT NULL,
+    poistui date,
+    seurue_id integer NOT NULL
+);
+
+
+ALTER TABLE public.jasenyys OWNER TO postgres;
+
+--
+-- TOC entry 3606 (class 0 OID 0)
+-- Dependencies: 223
+-- Name: COLUMN jasenyys.osuus; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.jasenyys.osuus IS 'Lihaosuus prosentteina';
+
+
+--
+-- TOC entry 224 (class 1259 OID 16731)
+-- Name: ryhmien_osuudet; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.ryhmien_osuudet AS
+ SELECT jasenyys.ryhma_id,
+    ((sum(jasenyys.osuus))::double precision / (100)::real) AS jakokerroin
+   FROM public.jasenyys
+  WHERE (jasenyys.poistui IS NULL)
+  GROUP BY jasenyys.ryhma_id
+  ORDER BY jasenyys.ryhma_id;
+
+
+ALTER TABLE public.ryhmien_osuudet OWNER TO postgres;
+
+--
+-- TOC entry 225 (class 1259 OID 16735)
+-- Name: jakoryhma_osuus_maara; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jakoryhma_osuus_maara AS
+ SELECT jakoryhma.ryhma_id,
+    jakoryhma.ryhman_nimi,
+    jakoryhma.seurue_id,
+    ryhmien_osuudet.jakokerroin AS osuus,
+    sum(jakotapahtuma.maara) AS maara
+   FROM ((public.jakoryhma
+     LEFT JOIN public.jakotapahtuma ON ((jakoryhma.ryhma_id = jakotapahtuma.ryhma_id)))
+     LEFT JOIN public.ryhmien_osuudet ON ((jakoryhma.ryhma_id = ryhmien_osuudet.ryhma_id)))
+  GROUP BY jakoryhma.ryhma_id, jakoryhma.ryhman_nimi, jakoryhma.seurue_id, ryhmien_osuudet.jakokerroin
+  ORDER BY jakoryhma.ryhma_id;
+
+
+ALTER TABLE public.jakoryhma_osuus_maara OWNER TO postgres;
+
+--
+-- TOC entry 226 (class 1259 OID 16740)
+-- Name: jakoryhma_ryhma_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.jakoryhma_ryhma_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.jakoryhma_ryhma_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3607 (class 0 OID 0)
+-- Dependencies: 226
+-- Name: jakoryhma_ryhma_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.jakoryhma_ryhma_id_seq OWNED BY public.jakoryhma.ryhma_id;
+
+
+--
+-- TOC entry 227 (class 1259 OID 16741)
+-- Name: seurue; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seurue (
+    seurue_id integer NOT NULL,
+    seura_id integer NOT NULL,
+    seurueen_nimi character varying(50) NOT NULL,
+    jasen_id integer NOT NULL,
+    seurue_tyyppi_id integer NOT NULL
+);
+
+
+ALTER TABLE public.seurue OWNER TO postgres;
+
+--
+-- TOC entry 3608 (class 0 OID 0)
+-- Dependencies: 227
+-- Name: TABLE seurue; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.seurue IS 'Metsästystä harjoittavan seurueen tiedot';
+
+
+--
+-- TOC entry 3609 (class 0 OID 0)
+-- Dependencies: 227
+-- Name: COLUMN seurue.jasen_id; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN public.seurue.jasen_id IS 'Seurueen johtajan tunniste';
+
+
+--
+-- TOC entry 228 (class 1259 OID 16744)
+-- Name: jakoryhma_seurueen_nimella; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jakoryhma_seurueen_nimella AS
+ SELECT jakoryhma.ryhma_id,
+    jakoryhma.ryhman_nimi,
+    jakoryhma.seurue_id,
+    seurue.seurueen_nimi
+   FROM (public.seurue
+     JOIN public.jakoryhma ON ((jakoryhma.seurue_id = seurue.seurue_id)))
+  ORDER BY jakoryhma.ryhma_id;
+
+
+ALTER TABLE public.jakoryhma_seurueen_nimella OWNER TO postgres;
+
+--
+-- TOC entry 229 (class 1259 OID 16748)
+-- Name: jakoryhma_yhteenveto; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jakoryhma_yhteenveto AS
+ SELECT jakoryhma.ryhman_nimi AS "Ryhmä",
+    count(jasenyys.jasen_id) AS "Jäseniä",
+    ((sum(jasenyys.osuus))::double precision / (100)::real) AS "Osuus Summa"
+   FROM (public.jakoryhma
+     LEFT JOIN public.jasenyys ON ((jasenyys.ryhma_id = jakoryhma.ryhma_id)))
+  WHERE (jasenyys.poistui IS NULL)
+  GROUP BY jakoryhma.ryhman_nimi
+  ORDER BY jakoryhma.ryhman_nimi;
+
+
+ALTER TABLE public.jakoryhma_yhteenveto OWNER TO postgres;
+
+--
+-- TOC entry 230 (class 1259 OID 16753)
+-- Name: jakotapahtuma_jasen_tapahtuma_jasen_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.jakotapahtuma_jasen_tapahtuma_jasen_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.jakotapahtuma_jasen_tapahtuma_jasen_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3610 (class 0 OID 0)
+-- Dependencies: 230
+-- Name: jakotapahtuma_jasen_tapahtuma_jasen_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.jakotapahtuma_jasen_tapahtuma_jasen_id_seq OWNED BY public.jakotapahtuma_jasen.tapahtuma_jasen_id;
+
+
+--
+-- TOC entry 231 (class 1259 OID 16754)
+-- Name: jakotapahtuma_ryhman_nimella; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jakotapahtuma_ryhman_nimella AS
+ SELECT jakotapahtuma.tapahtuma_id AS "Jako",
+    jakotapahtuma.paiva AS pvm,
+    jakotapahtuma.ryhma_id AS "Ryhmä ID",
+    jakoryhma.ryhman_nimi AS "Ryhmän Nimi",
+    jakotapahtuma.osnimitys AS "Ruhonosa",
+    jakotapahtuma.kaadon_kasittely_id AS "Kaadon kasittely ID",
+    jakotapahtuma.maara AS "Paino",
+    kaadon_kasittely.kaato_id AS "Kaato ID"
+   FROM ((public.jakotapahtuma
+     JOIN public.jakoryhma ON ((jakoryhma.ryhma_id = jakotapahtuma.ryhma_id)))
+     JOIN public.kaadon_kasittely ON ((kaadon_kasittely.kaadon_kasittely_id = jakotapahtuma.kaadon_kasittely_id)));
+
+
+ALTER TABLE public.jakotapahtuma_ryhman_nimella OWNER TO postgres;
+
+--
+-- TOC entry 232 (class 1259 OID 16758)
+-- Name: jakotapahtuma_tapahtuma_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.jakotapahtuma_tapahtuma_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.jakotapahtuma_tapahtuma_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3611 (class 0 OID 0)
+-- Dependencies: 232
+-- Name: jakotapahtuma_tapahtuma_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.jakotapahtuma_tapahtuma_id_seq OWNED BY public.jakotapahtuma.tapahtuma_id;
+
+
+--
+-- TOC entry 233 (class 1259 OID 16759)
+-- Name: jasen_jasen_id_seq_1; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.jasen_jasen_id_seq_1
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.jasen_jasen_id_seq_1 OWNER TO postgres;
+
+--
+-- TOC entry 3612 (class 0 OID 0)
+-- Dependencies: 233
+-- Name: jasen_jasen_id_seq_1; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.jasen_jasen_id_seq_1 OWNED BY public.jasen.jasen_id;
+
+
+--
+-- TOC entry 234 (class 1259 OID 16760)
+-- Name: jasen_tila; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jasen_tila AS
+ SELECT (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Nimi",
+    jasen.jakeluosoite AS "Osoite",
+    jasen.postinumero AS "Postinumero",
+    jasen.postitoimipaikka AS "Postitoimipaikka",
+    jasen.tila AS "Tila"
+   FROM public.jasen
+  ORDER BY (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text);
+
+
+ALTER TABLE public.jasen_tila OWNER TO postgres;
+
+--
+-- TOC entry 235 (class 1259 OID 16764)
+-- Name: jasenyys_jasenyys_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.jasenyys_jasenyys_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.jasenyys_jasenyys_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3613 (class 0 OID 0)
+-- Dependencies: 235
+-- Name: jasenyys_jasenyys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.jasenyys_jasenyys_id_seq OWNED BY public.jasenyys.jasenyys_id;
+
+
+--
+-- TOC entry 236 (class 1259 OID 16765)
+-- Name: jasenyys_nimella; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jasenyys_nimella AS
+ SELECT jasenyys.jasenyys_id,
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS kokonimi,
+    jasenyys.seurue_id
+   FROM (public.jasenyys
+     JOIN public.jasen ON ((jasen.jasen_id = jasenyys.jasen_id)));
+
+
+ALTER TABLE public.jasenyys_nimella OWNER TO postgres;
+
+--
+-- TOC entry 237 (class 1259 OID 16769)
+-- Name: seurue_tyyppi; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seurue_tyyppi (
+    seurue_tyyppi_id integer NOT NULL,
+    seurue_tyyppi_nimi character varying(20) NOT NULL
+);
+
+
+ALTER TABLE public.seurue_tyyppi OWNER TO postgres;
+
+--
+-- TOC entry 3614 (class 0 OID 0)
+-- Dependencies: 237
+-- Name: TABLE seurue_tyyppi; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.seurue_tyyppi IS 'Taulu, jonka tarkoitus on rajata tyyppi tietueen arvot seurue taulussa';
+
+
+--
+-- TOC entry 238 (class 1259 OID 16772)
+-- Name: jasenyys_nimella_ryhmalla; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.jasenyys_nimella_ryhmalla AS
+ SELECT (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Nimi",
+    jasenyys.jasenyys_id AS "JäsenyysID",
+    jasenyys.jasen_id AS "JäsenID",
+    jasenyys.ryhma_id AS "RyhmäID",
+    jakoryhma.ryhman_nimi AS "Ryhmän Nimi",
+    jasenyys.liittyi AS "Liittyi",
+    jasenyys.poistui AS "Poistui",
+    jasenyys.osuus AS "Osuus",
+    jasenyys.seurue_id AS "SeurueID",
+    seurue.seurueen_nimi AS "Seurueen Nimi",
+    seurue.seurue_tyyppi_id AS "Seurueen Tyyppi ID",
+    seurue_tyyppi.seurue_tyyppi_nimi AS "Seurueen Tyyppi"
+   FROM ((((public.jasenyys
+     JOIN public.jasen ON ((jasenyys.jasen_id = jasen.jasen_id)))
+     LEFT JOIN public.jakoryhma ON ((jasenyys.ryhma_id = jakoryhma.ryhma_id)))
+     JOIN public.seurue ON ((jasenyys.seurue_id = seurue.seurue_id)))
+     JOIN public.seurue_tyyppi ON ((seurue_tyyppi.seurue_tyyppi_id = seurue.seurue_tyyppi_id)))
+  ORDER BY (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text);
+
+
+ALTER TABLE public.jasenyys_nimella_ryhmalla OWNER TO postgres;
+
+--
+-- TOC entry 239 (class 1259 OID 16777)
+-- Name: kaadon_kasittely_kaadon_kasittely_id_seq_1; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.kaadon_kasittely_kaadon_kasittely_id_seq_1
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.kaadon_kasittely_kaadon_kasittely_id_seq_1 OWNER TO postgres;
+
+--
+-- TOC entry 3615 (class 0 OID 0)
+-- Dependencies: 239
+-- Name: kaadon_kasittely_kaadon_kasittely_id_seq_1; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.kaadon_kasittely_kaadon_kasittely_id_seq_1 OWNED BY public.kaadon_kasittely.kaadon_kasittely_id;
+
+
+--
+-- TOC entry 240 (class 1259 OID 16778)
+-- Name: kaato_kaato_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.kaato_kaato_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.kaato_kaato_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3616 (class 0 OID 0)
+-- Dependencies: 240
+-- Name: kaato_kaato_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.kaato_kaato_id_seq OWNED BY public.kaato.kaato_id;
+
+
+--
+-- TOC entry 241 (class 1259 OID 16779)
+-- Name: kaatoluettelo; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.kaatoluettelo AS
+ SELECT (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Kaataja",
+    kaato.kaatopaiva AS "Kaatopäivä",
+    kaato.paikka_teksti AS "Paikka",
+    kaato.elaimen_nimi AS "Eläin",
+    kaato.ikaluokka AS "Ikäluokka",
+    kaato.sukupuoli AS "Sukupuoli",
+    kaato.ruhopaino AS "Paino",
+    kaato.kaato_id AS "Kaato ID",
+    count(kaadon_kasittely.kaato_id) AS "Käsittelyt"
+   FROM ((public.kaato
+     JOIN public.jasen ON ((jasen.jasen_id = kaato.jasen_id)))
+     JOIN public.kaadon_kasittely ON ((kaato.kaato_id = kaadon_kasittely.kaato_id)))
+  GROUP BY (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text), kaato.kaatopaiva, kaato.paikka_teksti, kaato.elaimen_nimi, kaato.ikaluokka, kaato.sukupuoli, kaato.ruhopaino, kaato.kaato_id
+  ORDER BY kaato.kaato_id DESC;
+
+
+ALTER TABLE public.kaatoluettelo OWNER TO postgres;
+
+--
+-- TOC entry 242 (class 1259 OID 16784)
+-- Name: kaatoluettelo_indeksilla; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.kaatoluettelo_indeksilla AS
+ SELECT jasen.jasen_id AS "JäsenID",
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Kaataja",
+    kaato.kaatopaiva AS "Kaatopäivä",
+    kaato.paikka_teksti AS "Paikka",
+    kaato.elaimen_nimi AS "Eläin",
+    kaato.ikaluokka AS "Ikaluokka",
+    kaato.sukupuoli AS "Sukupuoli",
+    kaato.ruhopaino AS "Paino",
+    kaato.lisatieto AS "Lisätieto",
+    kaato.kaato_id AS "KaatoID"
+   FROM (public.jasen
+     JOIN public.kaato ON ((jasen.jasen_id = kaato.jasen_id)))
+  ORDER BY kaato.kaato_id DESC;
+
+
+ALTER TABLE public.kaatoluettelo_indeksilla OWNER TO postgres;
+
+--
+-- TOC entry 243 (class 1259 OID 16789)
+-- Name: kasittely_kasittelyid_seq_1; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.kasittely_kasittelyid_seq_1
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.kasittely_kasittelyid_seq_1 OWNER TO postgres;
+
+--
+-- TOC entry 3617 (class 0 OID 0)
+-- Dependencies: 243
+-- Name: kasittely_kasittelyid_seq_1; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.kasittely_kasittelyid_seq_1 OWNED BY public.kasittely.kasittelyid;
+
+
+--
+-- TOC entry 244 (class 1259 OID 16790)
+-- Name: lihan_kaytto; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.lihan_kaytto AS
+ SELECT kaato.elaimen_nimi AS source,
+    kasittely.kasittely_teksti AS target,
+    sum(kaato.ruhopaino) AS value
+   FROM ((public.kaadon_kasittely
+     JOIN public.kaato ON ((kaadon_kasittely.kaato_id = kaato.kaato_id)))
+     JOIN public.kasittely ON ((kaadon_kasittely.kasittelyid = kasittely.kasittelyid)))
+  GROUP BY kaato.elaimen_nimi, kasittely.kasittely_teksti;
+
+
+ALTER TABLE public.lihan_kaytto OWNER TO postgres;
+
+--
+-- TOC entry 245 (class 1259 OID 16795)
+-- Name: lupa; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.lupa (
+    luparivi_id integer NOT NULL,
+    seura_id integer NOT NULL,
+    lupavuosi character varying(4) NOT NULL,
+    elaimen_nimi character varying(20) NOT NULL,
+    sukupuoli character varying(20) NOT NULL,
+    ikaluokka character varying(20) NOT NULL,
+    maara integer NOT NULL
+);
+
+
+ALTER TABLE public.lupa OWNER TO postgres;
+
+--
+-- TOC entry 3618 (class 0 OID 0)
+-- Dependencies: 245
+-- Name: TABLE lupa; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.lupa IS 'Vuosittaiset kaatoluvat';
+
+
+--
+-- TOC entry 246 (class 1259 OID 16798)
+-- Name: lupa_luparivi_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.lupa_luparivi_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.lupa_luparivi_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3619 (class 0 OID 0)
+-- Dependencies: 246
+-- Name: lupa_luparivi_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.lupa_luparivi_id_seq OWNED BY public.lupa.luparivi_id;
+
+
+--
+-- TOC entry 247 (class 1259 OID 16799)
+-- Name: luvat_kayttamatta_kpl_pros; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.luvat_kayttamatta_kpl_pros AS
+ SELECT (lupa.maara - count(kaato.kaato_id)) AS "Lupia jäljellä",
+    (round((((100 * (lupa.maara - count(kaato.kaato_id))))::double precision / (lupa.maara)::double precision)))::integer AS "Lupia jäljellä(%)",
+    lupa.elaimen_nimi AS "Eläin",
+    lupa.sukupuoli AS "Sukupuoli",
+    lupa.ikaluokka AS "Ikäluokka"
+   FROM (public.lupa
+     LEFT JOIN public.kaato ON ((((lupa.sukupuoli)::text = (kaato.sukupuoli)::text) AND ((lupa.ikaluokka)::text = (kaato.ikaluokka)::text) AND ((kaato.elaimen_nimi)::text = (lupa.elaimen_nimi)::text))))
+  GROUP BY lupa.elaimen_nimi, lupa.maara, lupa.sukupuoli, lupa.ikaluokka
+  ORDER BY lupa.elaimen_nimi;
+
+
+ALTER TABLE public.luvat_kayttamatta_kpl_pros OWNER TO postgres;
+
+--
+-- TOC entry 248 (class 1259 OID 16804)
+-- Name: nimivalinta; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.nimivalinta AS
+ SELECT jasen.jasen_id,
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS kokonimi
+   FROM public.jasen
+  WHERE ((jasen.tila)::text = 'aktiivinen'::text)
+  ORDER BY (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text);
+
+
+ALTER TABLE public.nimivalinta OWNER TO postgres;
+
+--
+-- TOC entry 249 (class 1259 OID 16808)
+-- Name: ruhonosa; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.ruhonosa (
+    osnimitys character varying(20) NOT NULL
+);
+
+
+ALTER TABLE public.ruhonosa OWNER TO postgres;
+
+--
+-- TOC entry 250 (class 1259 OID 16811)
+-- Name: ryhmat_jasenilla; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.ryhmat_jasenilla AS
+ SELECT jakoryhma.ryhman_nimi AS "Ryhmän Nimi",
+    (((jasen.sukunimi)::text || ' '::text) || (jasen.etunimi)::text) AS "Nimi",
+    jasenyys.liittyi AS "Liittynyt",
+    jasenyys.poistui AS "Poistunut",
+    jasenyys.osuus AS "Osuus"
+   FROM ((public.jasenyys
+     JOIN public.jasen ON ((jasenyys.jasen_id = jasen.jasen_id)))
+     JOIN public.jakoryhma ON ((jakoryhma.ryhma_id = jasenyys.ryhma_id)))
+  ORDER BY jakoryhma.ryhman_nimi;
+
+
+ALTER TABLE public.ryhmat_jasenilla OWNER TO postgres;
+
+--
+-- TOC entry 3620 (class 0 OID 0)
+-- Dependencies: 250
+-- Name: VIEW ryhmat_jasenilla; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON VIEW public.ryhmat_jasenilla IS 'Näkymä joka näyttää ryhmä, jäsen, liittymispvm(,poistumispvm), osuus';
+
+
+--
+-- TOC entry 251 (class 1259 OID 16816)
+-- Name: seurue_sankey; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.seurue_sankey AS
+ SELECT kasittely.kasittely_teksti AS source,
+    seurue.seurueen_nimi AS target,
+    sum(jakotapahtuma.maara) AS sum
+   FROM ((((public.kasittely
+     JOIN public.kaadon_kasittely ON ((kasittely.kasittelyid = kaadon_kasittely.kasittelyid)))
+     JOIN public.jakotapahtuma ON ((kaadon_kasittely.kaadon_kasittely_id = jakotapahtuma.kaadon_kasittely_id)))
+     JOIN public.jakoryhma ON ((jakotapahtuma.ryhma_id = jakoryhma.ryhma_id)))
+     JOIN public.seurue ON ((jakoryhma.seurue_id = seurue.seurue_id)))
+  WHERE (kaadon_kasittely.kasittelyid = 2)
+  GROUP BY kasittely.kasittely_teksti, seurue.seurueen_nimi;
+
+
+ALTER TABLE public.seurue_sankey OWNER TO postgres;
+
+--
+-- TOC entry 252 (class 1259 OID 16821)
+-- Name: sankey_elain_kasittely_seurue; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.sankey_elain_kasittely_seurue AS
+ SELECT lihan_kaytto.source,
+    lihan_kaytto.target,
+    lihan_kaytto.value
+   FROM public.lihan_kaytto
+UNION
+ SELECT seurue_sankey.source,
+    seurue_sankey.target,
+    seurue_sankey.sum AS value
+   FROM public.seurue_sankey;
+
+
+ALTER TABLE public.sankey_elain_kasittely_seurue OWNER TO postgres;
+
+--
+-- TOC entry 253 (class 1259 OID 16825)
+-- Name: seura; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.seura (
+    seura_id integer NOT NULL,
+    seuran_nimi character varying(50) NOT NULL,
+    jakeluosoite character varying(30) NOT NULL,
+    postinumero character varying(10) NOT NULL,
+    postitoimipaikka character varying(30) NOT NULL
+);
+
+
+ALTER TABLE public.seura OWNER TO postgres;
+
+--
+-- TOC entry 3621 (class 0 OID 0)
+-- Dependencies: 253
+-- Name: TABLE seura; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON TABLE public.seura IS 'Metsästysseuran tiedot';
+
+
+--
+-- TOC entry 254 (class 1259 OID 16828)
+-- Name: seura_seura_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seura_seura_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.seura_seura_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3622 (class 0 OID 0)
+-- Dependencies: 254
+-- Name: seura_seura_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.seura_seura_id_seq OWNED BY public.seura.seura_id;
+
+
+--
+-- TOC entry 255 (class 1259 OID 16829)
+-- Name: seurue_lihat; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.seurue_lihat AS
+ SELECT seurue.seurue_id,
+    seurue.seurueen_nimi,
+    sum(jakotapahtuma.maara) AS sum
+   FROM ((public.seurue
+     JOIN public.jakoryhma ON ((jakoryhma.seurue_id = seurue.seurue_id)))
+     JOIN public.jakotapahtuma ON ((jakotapahtuma.ryhma_id = jakoryhma.ryhma_id)))
+  GROUP BY seurue.seurue_id, seurue.seurueen_nimi;
+
+
+ALTER TABLE public.seurue_lihat OWNER TO postgres;
+
+--
+-- TOC entry 256 (class 1259 OID 16834)
+-- Name: seurue_lihat_osuus; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.seurue_lihat_osuus AS
+ SELECT seurue.seurue_id,
+    seurue.seurueen_nimi,
+    seurue_lihat.sum AS maara,
+    ((sum(jasenyys.osuus))::real / (100)::real) AS osuus
+   FROM (((public.seurue
+     JOIN public.jakoryhma ON ((jakoryhma.seurue_id = seurue.seurue_id)))
+     JOIN public.jasenyys ON ((jasenyys.ryhma_id = jakoryhma.ryhma_id)))
+     JOIN public.seurue_lihat ON ((seurue_lihat.seurue_id = seurue.seurue_id)))
+  WHERE (jasenyys.poistui IS NULL)
+  GROUP BY seurue.seurue_id, seurue.seurueen_nimi, seurue_lihat.sum;
+
+
+ALTER TABLE public.seurue_lihat_osuus OWNER TO postgres;
+
+--
+-- TOC entry 257 (class 1259 OID 16839)
+-- Name: seurue_ryhmilla; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.seurue_ryhmilla AS
+ SELECT seurue.seurueen_nimi AS "Seurueen Nimi",
+    jakoryhma.ryhman_nimi AS "Ryhmän Nimi"
+   FROM (public.jakoryhma
+     JOIN public.seurue ON ((seurue.seurue_id = jakoryhma.seurue_id)))
+  ORDER BY jakoryhma.ryhman_nimi;
+
+
+ALTER TABLE public.seurue_ryhmilla OWNER TO postgres;
+
+--
+-- TOC entry 258 (class 1259 OID 16843)
+-- Name: seurue_seurue_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seurue_seurue_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.seurue_seurue_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3623 (class 0 OID 0)
+-- Dependencies: 258
+-- Name: seurue_seurue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.seurue_seurue_id_seq OWNED BY public.seurue.seurue_id;
+
+
+--
+-- TOC entry 259 (class 1259 OID 16844)
+-- Name: seurue_tyyppi_seurue_tyyppi_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.seurue_tyyppi_seurue_tyyppi_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.seurue_tyyppi_seurue_tyyppi_id_seq OWNER TO postgres;
+
+--
+-- TOC entry 3624 (class 0 OID 0)
+-- Dependencies: 259
+-- Name: seurue_tyyppi_seurue_tyyppi_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.seurue_tyyppi_seurue_tyyppi_id_seq OWNED BY public.seurue_tyyppi.seurue_tyyppi_id;
+
+
+--
+-- TOC entry 260 (class 1259 OID 16845)
+-- Name: sukupuoli; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sukupuoli (
+    sukupuoli character varying(20) NOT NULL
+);
+
+
+ALTER TABLE public.sukupuoli OWNER TO postgres;
+
+--
+-- TOC entry 3332 (class 2604 OID 16848)
+-- Name: jakoryhma ryhma_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakoryhma ALTER COLUMN ryhma_id SET DEFAULT nextval('public.jakoryhma_ryhma_id_seq'::regclass);
+
+
+--
+-- TOC entry 3333 (class 2604 OID 16849)
+-- Name: jakotapahtuma tapahtuma_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma ALTER COLUMN tapahtuma_id SET DEFAULT nextval('public.jakotapahtuma_tapahtuma_id_seq'::regclass);
+
+
+--
+-- TOC entry 3336 (class 2604 OID 16850)
+-- Name: jakotapahtuma_jasen tapahtuma_jasen_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma_jasen ALTER COLUMN tapahtuma_jasen_id SET DEFAULT nextval('public.jakotapahtuma_jasen_tapahtuma_jasen_id_seq'::regclass);
+
+
+--
+-- TOC entry 3338 (class 2604 OID 16851)
+-- Name: jasen jasen_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasen ALTER COLUMN jasen_id SET DEFAULT nextval('public.jasen_jasen_id_seq_1'::regclass);
+
+
+--
+-- TOC entry 3340 (class 2604 OID 16852)
+-- Name: jasenyys jasenyys_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasenyys ALTER COLUMN jasenyys_id SET DEFAULT nextval('public.jasenyys_jasenyys_id_seq'::regclass);
+
+
+--
+-- TOC entry 3334 (class 2604 OID 16853)
+-- Name: kaadon_kasittely kaadon_kasittely_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaadon_kasittely ALTER COLUMN kaadon_kasittely_id SET DEFAULT nextval('public.kaadon_kasittely_kaadon_kasittely_id_seq_1'::regclass);
+
+
+--
+-- TOC entry 3335 (class 2604 OID 16854)
+-- Name: kaato kaato_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato ALTER COLUMN kaato_id SET DEFAULT nextval('public.kaato_kaato_id_seq'::regclass);
+
+
+--
+-- TOC entry 3339 (class 2604 OID 16855)
+-- Name: kasittely kasittelyid; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kasittely ALTER COLUMN kasittelyid SET DEFAULT nextval('public.kasittely_kasittelyid_seq_1'::regclass);
+
+
+--
+-- TOC entry 3343 (class 2604 OID 16856)
+-- Name: lupa luparivi_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa ALTER COLUMN luparivi_id SET DEFAULT nextval('public.lupa_luparivi_id_seq'::regclass);
+
+
+--
+-- TOC entry 3344 (class 2604 OID 16857)
+-- Name: seura seura_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seura ALTER COLUMN seura_id SET DEFAULT nextval('public.seura_seura_id_seq'::regclass);
+
+
+--
+-- TOC entry 3341 (class 2604 OID 16858)
+-- Name: seurue seurue_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue ALTER COLUMN seurue_id SET DEFAULT nextval('public.seurue_seurue_id_seq'::regclass);
+
+
+--
+-- TOC entry 3342 (class 2604 OID 16859)
+-- Name: seurue_tyyppi seurue_tyyppi_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue_tyyppi ALTER COLUMN seurue_tyyppi_id SET DEFAULT nextval('public.seurue_tyyppi_seurue_tyyppi_id_seq'::regclass);
+
+
+--
+-- TOC entry 3566 (class 0 OID 16674)
+-- Dependencies: 209
+-- Data for Name: aikuinenvasa; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.aikuinenvasa VALUES ('Vasa');
+INSERT INTO public.aikuinenvasa VALUES ('Aikuinen');
+
+
+--
+-- TOC entry 3567 (class 0 OID 16677)
+-- Dependencies: 210
+-- Data for Name: elain; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.elain VALUES ('Valkohäntäpeura');
+INSERT INTO public.elain VALUES ('Hirvi');
+
+
+--
+-- TOC entry 3568 (class 0 OID 16680)
+-- Dependencies: 211
+-- Data for Name: jakoryhma; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.jakoryhma VALUES (1, 1, 'Ryhmä1');
+INSERT INTO public.jakoryhma VALUES (2, 1, 'Ryhmä2');
+INSERT INTO public.jakoryhma VALUES (3, 1, 'Ryhmä3');
+INSERT INTO public.jakoryhma VALUES (4, 1, 'Ryhmä4');
+INSERT INTO public.jakoryhma VALUES (5, 1, 'Ryhmä5');
+INSERT INTO public.jakoryhma VALUES (6, 1, 'Ryhmä6');
+INSERT INTO public.jakoryhma VALUES (7, 1, 'Ryhmä7');
+
+
+--
+-- TOC entry 3569 (class 0 OID 16683)
+-- Dependencies: 212
+-- Data for Name: jakotapahtuma; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.jakotapahtuma VALUES (5, '2023-09-04', 6, 'Neljännes', 1, 50);
+INSERT INTO public.jakotapahtuma VALUES (6, '2023-09-05', 3, 'Puolikas', 5, 40);
+INSERT INTO public.jakotapahtuma VALUES (7, '2023-09-05', 4, 'Puolikas', 5, 40);
+INSERT INTO public.jakotapahtuma VALUES (8, '2023-09-05', 7, 'Neljännes', 1, 50);
+INSERT INTO public.jakotapahtuma VALUES (9, '2023-09-05', 1, 'Puolikas', 6, 30);
+INSERT INTO public.jakotapahtuma VALUES (10, '2023-09-18', 7, 'Koko', 8, 100);
+INSERT INTO public.jakotapahtuma VALUES (1, '2023-09-04', 1, 'Koko', 2, 200);
+INSERT INTO public.jakotapahtuma VALUES (4, '2023-09-04', 5, 'Neljännes', 4, 220);
+INSERT INTO public.jakotapahtuma VALUES (3, '2023-09-04', 4, 'Puolikas', 1, 100);
+
+
+--
+-- TOC entry 3572 (class 0 OID 16703)
+-- Dependencies: 217
+-- Data for Name: jakotapahtuma_jasen; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.jakotapahtuma_jasen VALUES (1, '2022-11-15', 9, 'Koko', 89, 37);
+INSERT INTO public.jakotapahtuma_jasen VALUES (2, '2022-11-15', 10, 'Puolikas', 45, 38);
+
+
+--
+-- TOC entry 3573 (class 0 OID 16711)
+-- Dependencies: 219
+-- Data for Name: jasen; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.jasen VALUES (1, 'Kimmo', 'Suominen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (2, 'Niko', 'Aalto', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (3, 'Matti', 'Karhunen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (4, 'Antti', 'Heinonen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (5, 'Antti-Juhani', 'Laitinen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (6, 'Ari', 'Halonen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (7, 'Esko', 'Runola', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (8, 'Miikka', 'Hiivola', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (9, 'Ari', 'Junttila', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (10, 'Timo', 'Nurmi', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (12, 'Risto', 'Leppänen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (13, 'Timo', 'Kyrölä', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (14, 'Ari', 'Kilpeläinen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (15, 'Esa', 'Kilpeläinen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (16, 'Marko', 'Hannula', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (17, 'Jari', 'Kaskinen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (18, 'Arto', 'Ali-Keskikylä', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (19, 'Mikko', 'Luostarinen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (20, 'Niko', 'Rannikko', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (21, 'Matti', 'Van Strien', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (22, 'Juha-Matti', 'Halminen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (23, 'Aleksi', 'Ahlqvist', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (24, 'Pentti', 'Ahlqvist', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (25, 'Tuomas', 'Ahlqvist', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (26, 'Tommi', 'Puntala', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (27, 'Juha-Matti', 'Hannula', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (28, 'Tapio', 'Ranta', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (29, 'Vilho', 'Länsiaho', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (30, 'Antti', 'Keskitalo', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (31, 'Sauli', 'Junttila', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (32, 'Mikko', 'Mäkilä', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (33, 'Mikko', 'Salminen', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (11, 'Erkki', 'Lehto', '-', '-', '-', 'aktiivinen');
+INSERT INTO public.jasen VALUES (34, 'Matti', 'Rinnola', '-', '-', '-', 'aktiivinen');
+
+
+--
+-- TOC entry 3575 (class 0 OID 16728)
+-- Dependencies: 223
+-- Data for Name: jasenyys; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.jasenyys VALUES (1, 1, 3, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (2, 1, 1, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (3, 1, 4, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (4, 1, 5, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (5, 2, 6, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (6, 2, 33, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (7, 2, 7, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (8, 2, 8, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (9, 3, 9, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (10, 3, 10, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (11, 3, 11, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (12, 3, 12, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (13, 4, 13, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (14, 4, 14, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (15, 4, 15, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (16, 4, 16, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (17, 5, 17, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (18, 5, 34, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (19, 5, 18, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (20, 5, 19, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (21, 6, 20, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (22, 6, 21, 100, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (23, 6, 22, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (24, 6, 23, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (25, 6, 24, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (26, 6, 25, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (27, 7, 26, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (28, 7, 27, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (29, 7, 28, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (30, 7, 29, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (31, 7, 30, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (32, 7, 31, 50, '2023-05-23', NULL, 1);
+INSERT INTO public.jasenyys VALUES (37, NULL, 2, 100, '2023-10-03', NULL, 2);
+INSERT INTO public.jasenyys VALUES (38, NULL, 23, 100, '2023-10-03', NULL, 2);
+INSERT INTO public.jasenyys VALUES (39, NULL, 24, 100, '2023-10-03', NULL, 2);
+INSERT INTO public.jasenyys VALUES (40, NULL, 25, 100, '2023-10-03', NULL, 2);
+INSERT INTO public.jasenyys VALUES (33, 7, 32, 50, '2023-05-23', NULL, 1);
+
+
+--
+-- TOC entry 3570 (class 0 OID 16690)
+-- Dependencies: 214
+-- Data for Name: kaadon_kasittely; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.kaadon_kasittely VALUES (1, 2, 4, 100);
+INSERT INTO public.kaadon_kasittely VALUES (2, 2, 5, 100);
+INSERT INTO public.kaadon_kasittely VALUES (6, 2, 8, 50);
+INSERT INTO public.kaadon_kasittely VALUES (7, 3, 8, 50);
+INSERT INTO public.kaadon_kasittely VALUES (5, 2, 7, 100);
+INSERT INTO public.kaadon_kasittely VALUES (3, 1, 6, 75);
+INSERT INTO public.kaadon_kasittely VALUES (4, 2, 6, 25);
+INSERT INTO public.kaadon_kasittely VALUES (8, 2, 9, 100);
+INSERT INTO public.kaadon_kasittely VALUES (9, 5, 11, 100);
+INSERT INTO public.kaadon_kasittely VALUES (10, 5, 12, 100);
+
+
+--
+-- TOC entry 3571 (class 0 OID 16693)
+-- Dependencies: 215
+-- Data for Name: kaato; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.kaato VALUES (4, 2, '2023-09-04', 200, 'Turku', NULL, 'Hirvi', 'Uros', 'Aikuinen', NULL);
+INSERT INTO public.kaato VALUES (5, 24, '2023-09-04', 125, 'Raisio', NULL, 'Hirvi', 'Naaras', 'Aikuinen', NULL);
+INSERT INTO public.kaato VALUES (8, 12, '2023-09-05', 60, 'Masku', NULL, 'Valkohäntäpeura', 'Naaras', 'Aikuinen', NULL);
+INSERT INTO public.kaato VALUES (7, 34, '2023-09-05', 80, 'Vantaa', NULL, 'Valkohäntäpeura', 'Uros', 'Aikuinen', 'None');
+INSERT INTO public.kaato VALUES (6, 8, '2023-09-04', 220, 'Muuntula', NULL, 'Hirvi', 'Uros', 'Aikuinen', 'None');
+INSERT INTO public.kaato VALUES (9, 10, '2023-09-18', 100, 'Turku', NULL, 'Valkohäntäpeura', 'Uros', 'Vasa', NULL);
+INSERT INTO public.kaato VALUES (11, 24, '2023-09-28', 89, 'Tampere', NULL, 'Valkohäntäpeura', 'Uros', 'Aikuinen', NULL);
+INSERT INTO public.kaato VALUES (12, 9, '2023-10-04', 90, 'Tuolla', NULL, 'Valkohäntäpeura', 'Uros', 'Aikuinen', NULL);
+
+
+--
+-- TOC entry 3574 (class 0 OID 16715)
+-- Dependencies: 220
+-- Data for Name: kasittely; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.kasittely VALUES (1, 'Seuralle');
+INSERT INTO public.kasittely VALUES (2, 'Seurueelle');
+INSERT INTO public.kasittely VALUES (3, 'Myyntiin');
+INSERT INTO public.kasittely VALUES (4, 'Hävitetään');
+INSERT INTO public.kasittely VALUES (5, 'Jäsenelle');
+
+
+--
+-- TOC entry 3586 (class 0 OID 16795)
+-- Dependencies: 245
+-- Data for Name: lupa; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.lupa VALUES (1, 1, '2023', 'Hirvi', 'Naaras', 'Aikuinen', 8);
+INSERT INTO public.lupa VALUES (2, 1, '2023', 'Hirvi', 'Uros', 'Aikuinen', 9);
+INSERT INTO public.lupa VALUES (3, 1, '2023', 'Hirvi', 'Ei määritelty', 'Vasa', 16);
+INSERT INTO public.lupa VALUES (13, 1, '2023', 'Valkohäntäpeura', 'Ei määritelty', 'Vasa', 200);
+INSERT INTO public.lupa VALUES (14, 1, '2023', 'Valkohäntäpeura', 'Uros', 'Aikuinen', 112);
+INSERT INTO public.lupa VALUES (15, 1, '2023', 'Valkohäntäpeura', 'Naaras', 'Aikuinen', 128);
+INSERT INTO public.lupa VALUES (4, 1, '2022', 'Valkohäntäpeura', 'Uros', 'Aikuinen', 104);
+INSERT INTO public.lupa VALUES (10, 1, '2022', 'Valkohäntäpeura', 'Ei määritelty', 'Vasa', 188);
+INSERT INTO public.lupa VALUES (12, 1, '2022', 'Valkohäntäpeura', 'Naaras', 'Aikuinen', 84);
+INSERT INTO public.lupa VALUES (5, 1, '2021', 'Valkohäntäpeura', 'Uros', 'Aikuinen', 90);
+INSERT INTO public.lupa VALUES (9, 1, '2021', 'Valkohäntäpeura', 'Naaras', 'Aikuinen', 90);
+INSERT INTO public.lupa VALUES (11, 1, '2021', 'Valkohäntäpeura', 'Ei määritelty', 'Vasa', 150);
+INSERT INTO public.lupa VALUES (6, 1, '2020', 'Valkohäntäpeura', 'Uros', 'Aikuinen', 150);
+INSERT INTO public.lupa VALUES (7, 1, '2020', 'Valkohäntäpeura', 'Naaras', 'Aikuinen', 185);
+INSERT INTO public.lupa VALUES (8, 1, '2020', 'Valkohäntäpeura', 'Ei määritelty', 'Vasa', 250);
+
+
+--
+-- TOC entry 3588 (class 0 OID 16808)
+-- Dependencies: 249
+-- Data for Name: ruhonosa; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.ruhonosa VALUES ('Koko');
+INSERT INTO public.ruhonosa VALUES ('Puolikas');
+INSERT INTO public.ruhonosa VALUES ('Neljännes');
+
+
+--
+-- TOC entry 3589 (class 0 OID 16825)
+-- Dependencies: 253
+-- Data for Name: seura; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.seura VALUES (1, 'Metsästysseura Repo ry', 'Ketoruusuntie 26', '21270', 'Nousiainen');
+
+
+--
+-- TOC entry 3577 (class 0 OID 16741)
+-- Dependencies: 227
+-- Data for Name: seurue; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.seurue VALUES (1, 1, 'Ryhmä Seurue', 1, 1);
+INSERT INTO public.seurue VALUES (2, 1, 'Jäsen Seurue', 2, 2);
+
+
+--
+-- TOC entry 3582 (class 0 OID 16769)
+-- Dependencies: 237
+-- Data for Name: seurue_tyyppi; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.seurue_tyyppi VALUES (1, 'Ryhmä');
+INSERT INTO public.seurue_tyyppi VALUES (2, 'Jäsen');
+
+
+--
+-- TOC entry 3593 (class 0 OID 16845)
+-- Dependencies: 260
+-- Data for Name: sukupuoli; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+INSERT INTO public.sukupuoli VALUES ('Uros');
+INSERT INTO public.sukupuoli VALUES ('Naaras');
+INSERT INTO public.sukupuoli VALUES ('Ei määritelty');
+
+
+--
+-- TOC entry 3625 (class 0 OID 0)
+-- Dependencies: 226
+-- Name: jakoryhma_ryhma_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.jakoryhma_ryhma_id_seq', 7, true);
+
+
+--
+-- TOC entry 3626 (class 0 OID 0)
+-- Dependencies: 230
+-- Name: jakotapahtuma_jasen_tapahtuma_jasen_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.jakotapahtuma_jasen_tapahtuma_jasen_id_seq', 2, true);
+
+
+--
+-- TOC entry 3627 (class 0 OID 0)
+-- Dependencies: 232
+-- Name: jakotapahtuma_tapahtuma_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.jakotapahtuma_tapahtuma_id_seq', 10, true);
+
+
+--
+-- TOC entry 3628 (class 0 OID 0)
+-- Dependencies: 233
+-- Name: jasen_jasen_id_seq_1; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.jasen_jasen_id_seq_1', 34, true);
+
+
+--
+-- TOC entry 3629 (class 0 OID 0)
+-- Dependencies: 235
+-- Name: jasenyys_jasenyys_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.jasenyys_jasenyys_id_seq', 40, true);
+
+
+--
+-- TOC entry 3630 (class 0 OID 0)
+-- Dependencies: 239
+-- Name: kaadon_kasittely_kaadon_kasittely_id_seq_1; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.kaadon_kasittely_kaadon_kasittely_id_seq_1', 10, true);
+
+
+--
+-- TOC entry 3631 (class 0 OID 0)
+-- Dependencies: 240
+-- Name: kaato_kaato_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.kaato_kaato_id_seq', 12, true);
+
+
+--
+-- TOC entry 3632 (class 0 OID 0)
+-- Dependencies: 243
+-- Name: kasittely_kasittelyid_seq_1; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.kasittely_kasittelyid_seq_1', 1, true);
+
+
+--
+-- TOC entry 3633 (class 0 OID 0)
+-- Dependencies: 246
+-- Name: lupa_luparivi_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.lupa_luparivi_id_seq', 15, true);
+
+
+--
+-- TOC entry 3634 (class 0 OID 0)
+-- Dependencies: 254
+-- Name: seura_seura_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.seura_seura_id_seq', 1, true);
+
+
+--
+-- TOC entry 3635 (class 0 OID 0)
+-- Dependencies: 258
+-- Name: seurue_seurue_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.seurue_seurue_id_seq', 3, true);
+
+
+--
+-- TOC entry 3636 (class 0 OID 0)
+-- Dependencies: 259
+-- Name: seurue_tyyppi_seurue_tyyppi_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.seurue_tyyppi_seurue_tyyppi_id_seq', 2, true);
+
+
+--
+-- TOC entry 3346 (class 2606 OID 16861)
+-- Name: aikuinenvasa aikuinenvasa_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.aikuinenvasa
+    ADD CONSTRAINT aikuinenvasa_pk PRIMARY KEY (ikaluokka);
+
+
+--
+-- TOC entry 3348 (class 2606 OID 16863)
+-- Name: elain elain_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.elain
+    ADD CONSTRAINT elain_pk PRIMARY KEY (elaimen_nimi);
+
+
+--
+-- TOC entry 3350 (class 2606 OID 16865)
+-- Name: jakoryhma jakoryhma_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakoryhma
+    ADD CONSTRAINT jakoryhma_pk PRIMARY KEY (ryhma_id);
+
+
+--
+-- TOC entry 3359 (class 2606 OID 16867)
+-- Name: jakotapahtuma_jasen jakotapahtuma_jasen_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma_jasen
+    ADD CONSTRAINT jakotapahtuma_jasen_pk PRIMARY KEY (tapahtuma_jasen_id);
+
+
+--
+-- TOC entry 3352 (class 2606 OID 16869)
+-- Name: jakotapahtuma jakotapahtuma_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma
+    ADD CONSTRAINT jakotapahtuma_pk PRIMARY KEY (tapahtuma_id);
+
+
+--
+-- TOC entry 3361 (class 2606 OID 16871)
+-- Name: jasen jasen_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasen
+    ADD CONSTRAINT jasen_pk PRIMARY KEY (jasen_id);
+
+
+--
+-- TOC entry 3366 (class 2606 OID 16873)
+-- Name: jasenyys jasenyys_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasenyys
+    ADD CONSTRAINT jasenyys_pk PRIMARY KEY (jasenyys_id);
+
+
+--
+-- TOC entry 3354 (class 2606 OID 16875)
+-- Name: kaadon_kasittely kaadon_kasittely_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaadon_kasittely
+    ADD CONSTRAINT kaadon_kasittely_pk PRIMARY KEY (kaadon_kasittely_id);
+
+
+--
+-- TOC entry 3356 (class 2606 OID 16877)
+-- Name: kaato kaato_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato
+    ADD CONSTRAINT kaato_pk PRIMARY KEY (kaato_id);
+
+
+--
+-- TOC entry 3363 (class 2606 OID 16879)
+-- Name: kasittely kasittely_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kasittely
+    ADD CONSTRAINT kasittely_pk PRIMARY KEY (kasittelyid);
+
+
+--
+-- TOC entry 3373 (class 2606 OID 16881)
+-- Name: lupa lupa_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa
+    ADD CONSTRAINT lupa_pk PRIMARY KEY (luparivi_id);
+
+
+--
+-- TOC entry 3375 (class 2606 OID 16883)
+-- Name: ruhonosa ruhonosa_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.ruhonosa
+    ADD CONSTRAINT ruhonosa_pk PRIMARY KEY (osnimitys);
+
+
+--
+-- TOC entry 3377 (class 2606 OID 16885)
+-- Name: seura seura_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seura
+    ADD CONSTRAINT seura_pk PRIMARY KEY (seura_id);
+
+
+--
+-- TOC entry 3369 (class 2606 OID 16887)
+-- Name: seurue seurue_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue
+    ADD CONSTRAINT seurue_pk PRIMARY KEY (seurue_id);
+
+
+--
+-- TOC entry 3371 (class 2606 OID 16889)
+-- Name: seurue_tyyppi seurue_tyyppi_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue_tyyppi
+    ADD CONSTRAINT seurue_tyyppi_pk PRIMARY KEY (seurue_tyyppi_id);
+
+
+--
+-- TOC entry 3379 (class 2606 OID 16891)
+-- Name: sukupuoli sukupuoli_pk; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sukupuoli
+    ADD CONSTRAINT sukupuoli_pk PRIMARY KEY (sukupuoli);
+
+
+--
+-- TOC entry 3357 (class 1259 OID 16892)
+-- Name: fki_jasenyys_jakotapahtuma_jasen_fk; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX fki_jasenyys_jakotapahtuma_jasen_fk ON public.jakotapahtuma_jasen USING btree (jasenyys_id);
+
+
+--
+-- TOC entry 3364 (class 1259 OID 16893)
+-- Name: fki_seurue_jasenyys_fk; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX fki_seurue_jasenyys_fk ON public.jasenyys USING btree (seurue_id);
+
+
+--
+-- TOC entry 3367 (class 1259 OID 16894)
+-- Name: fki_seurue_tyyppi_seurue_fk; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX fki_seurue_tyyppi_seurue_fk ON public.seurue USING btree (seurue_tyyppi_id);
+
+
+--
+-- TOC entry 3386 (class 2606 OID 16895)
+-- Name: kaato aikuinen_vasa_kaato_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato
+    ADD CONSTRAINT aikuinen_vasa_kaato_fk FOREIGN KEY (ikaluokka) REFERENCES public.aikuinenvasa(ikaluokka);
+
+
+--
+-- TOC entry 3399 (class 2606 OID 16900)
+-- Name: lupa aikuinen_vasa_lupa_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa
+    ADD CONSTRAINT aikuinen_vasa_lupa_fk FOREIGN KEY (ikaluokka) REFERENCES public.aikuinenvasa(ikaluokka);
+
+
+--
+-- TOC entry 3387 (class 2606 OID 16905)
+-- Name: kaato elain_kaato_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato
+    ADD CONSTRAINT elain_kaato_fk FOREIGN KEY (elaimen_nimi) REFERENCES public.elain(elaimen_nimi);
+
+
+--
+-- TOC entry 3400 (class 2606 OID 16910)
+-- Name: lupa elain_lupa_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa
+    ADD CONSTRAINT elain_lupa_fk FOREIGN KEY (elaimen_nimi) REFERENCES public.elain(elaimen_nimi);
+
+
+--
+-- TOC entry 3393 (class 2606 OID 16915)
+-- Name: jasenyys jasen_jasenyys_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasenyys
+    ADD CONSTRAINT jasen_jasenyys_fk FOREIGN KEY (jasen_id) REFERENCES public.jasen(jasen_id);
+
+
+--
+-- TOC entry 3388 (class 2606 OID 16920)
+-- Name: kaato jasen_kaato_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato
+    ADD CONSTRAINT jasen_kaato_fk FOREIGN KEY (jasen_id) REFERENCES public.jasen(jasen_id);
+
+
+--
+-- TOC entry 3396 (class 2606 OID 16925)
+-- Name: seurue jasen_seurue_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue
+    ADD CONSTRAINT jasen_seurue_fk FOREIGN KEY (jasen_id) REFERENCES public.jasen(jasen_id);
+
+
+--
+-- TOC entry 3390 (class 2606 OID 16930)
+-- Name: jakotapahtuma_jasen jasenyys_jakotapahtuma_jasen_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma_jasen
+    ADD CONSTRAINT jasenyys_jakotapahtuma_jasen_fk FOREIGN KEY (jasenyys_id) REFERENCES public.jasenyys(jasenyys_id);
+
+
+--
+-- TOC entry 3381 (class 2606 OID 16935)
+-- Name: jakotapahtuma kaadon_kasittely_jakotapahtuma_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma
+    ADD CONSTRAINT kaadon_kasittely_jakotapahtuma_fk FOREIGN KEY (kaadon_kasittely_id) REFERENCES public.kaadon_kasittely(kaadon_kasittely_id) ON DELETE CASCADE;
+
+
+--
+-- TOC entry 3391 (class 2606 OID 16940)
+-- Name: jakotapahtuma_jasen kaadon_kasittely_jakotapahtuma_jasen_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma_jasen
+    ADD CONSTRAINT kaadon_kasittely_jakotapahtuma_jasen_fk FOREIGN KEY (kaadon_kasittely_id) REFERENCES public.kaadon_kasittely(kaadon_kasittely_id) ON DELETE CASCADE;
+
+
+--
+-- TOC entry 3384 (class 2606 OID 16945)
+-- Name: kaadon_kasittely kaato_kaadon_kasittely_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaadon_kasittely
+    ADD CONSTRAINT kaato_kaadon_kasittely_fk FOREIGN KEY (kaato_id) REFERENCES public.kaato(kaato_id) ON DELETE CASCADE;
+
+
+--
+-- TOC entry 3385 (class 2606 OID 16950)
+-- Name: kaadon_kasittely kasittely_kaadon_kasittely_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaadon_kasittely
+    ADD CONSTRAINT kasittely_kaadon_kasittely_fk FOREIGN KEY (kasittelyid) REFERENCES public.kasittely(kasittelyid);
+
+
+--
+-- TOC entry 3382 (class 2606 OID 16955)
+-- Name: jakotapahtuma ruhonosa_jakotapahtuma_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma
+    ADD CONSTRAINT ruhonosa_jakotapahtuma_fk FOREIGN KEY (osnimitys) REFERENCES public.ruhonosa(osnimitys);
+
+
+--
+-- TOC entry 3392 (class 2606 OID 16960)
+-- Name: jakotapahtuma_jasen ruhonosa_jakotapahtuma_jasen_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma_jasen
+    ADD CONSTRAINT ruhonosa_jakotapahtuma_jasen_fk FOREIGN KEY (osnimitys) REFERENCES public.ruhonosa(osnimitys);
+
+
+--
+-- TOC entry 3383 (class 2606 OID 16965)
+-- Name: jakotapahtuma ryhma_jakotapahtuma_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakotapahtuma
+    ADD CONSTRAINT ryhma_jakotapahtuma_fk FOREIGN KEY (ryhma_id) REFERENCES public.jakoryhma(ryhma_id);
+
+
+--
+-- TOC entry 3394 (class 2606 OID 16970)
+-- Name: jasenyys ryhma_jasenyys_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasenyys
+    ADD CONSTRAINT ryhma_jasenyys_fk FOREIGN KEY (ryhma_id) REFERENCES public.jakoryhma(ryhma_id);
+
+
+--
+-- TOC entry 3401 (class 2606 OID 16975)
+-- Name: lupa seura_lupa_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa
+    ADD CONSTRAINT seura_lupa_fk FOREIGN KEY (seura_id) REFERENCES public.seura(seura_id);
+
+
+--
+-- TOC entry 3397 (class 2606 OID 16980)
+-- Name: seurue seura_seurue_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue
+    ADD CONSTRAINT seura_seurue_fk FOREIGN KEY (seura_id) REFERENCES public.seura(seura_id);
+
+
+--
+-- TOC entry 3395 (class 2606 OID 16985)
+-- Name: jasenyys seurue_jasenyys_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jasenyys
+    ADD CONSTRAINT seurue_jasenyys_fk FOREIGN KEY (seurue_id) REFERENCES public.seurue(seurue_id);
+
+
+--
+-- TOC entry 3380 (class 2606 OID 16990)
+-- Name: jakoryhma seurue_ryhma_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.jakoryhma
+    ADD CONSTRAINT seurue_ryhma_fk FOREIGN KEY (seurue_id) REFERENCES public.seurue(seurue_id);
+
+
+--
+-- TOC entry 3398 (class 2606 OID 16995)
+-- Name: seurue seurue_tyyppi_seurue_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.seurue
+    ADD CONSTRAINT seurue_tyyppi_seurue_fk FOREIGN KEY (seurue_tyyppi_id) REFERENCES public.seurue_tyyppi(seurue_tyyppi_id);
+
+
+--
+-- TOC entry 3389 (class 2606 OID 17000)
+-- Name: kaato sukupuoli_kaato_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kaato
+    ADD CONSTRAINT sukupuoli_kaato_fk FOREIGN KEY (sukupuoli) REFERENCES public.sukupuoli(sukupuoli);
+
+
+--
+-- TOC entry 3402 (class 2606 OID 17005)
+-- Name: lupa sukupuoli_lupa_fk; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.lupa
+    ADD CONSTRAINT sukupuoli_lupa_fk FOREIGN KEY (sukupuoli) REFERENCES public.sukupuoli(sukupuoli);
+
+
+-- Completed on 2023-10-05 00:09:02
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/database/migrations/2023-10-02/create_view_jaetut_ruhon_osat_jasenille.sql
+++ b/database/migrations/2023-10-02/create_view_jaetut_ruhon_osat_jasenille.sql
@@ -1,0 +1,19 @@
+-- View for showing all the parts of the carcass that have been shared to the members
+
+CREATE OR REPLACE VIEW public.jaetut_ruhon_osat_jasenille
+ AS
+ SELECT kaato.kaato_id AS "KaatoID",
+    kaato.elaimen_nimi AS "Eläin",
+    jakotapahtuma_jasen.osnimitys AS "Ruhon osa",
+    jakotapahtuma_jasen.maara AS "Määrä",
+    kaadon_kasittely.kasittely_maara AS "Käsittelyn Määrä"
+   FROM kaato
+     JOIN kaadon_kasittely ON kaadon_kasittely.kaato_id = kaato.kaato_id
+     JOIN jakotapahtuma_jasen ON jakotapahtuma_jasen.kaadon_kasittely_id = kaadon_kasittely.kaadon_kasittely_id
+  ORDER BY kaato.kaato_id DESC;
+
+ALTER TABLE public.jaetut_ruhon_osat_jasenille
+    OWNER TO postgres;
+
+GRANT ALL ON TABLE public.jaetut_ruhon_osat_jasenille TO application;
+GRANT ALL ON TABLE public.jaetut_ruhon_osat_jasenille TO postgres;

--- a/desktopApp/Jahtirekisteri.py
+++ b/desktopApp/Jahtirekisteri.py
@@ -100,7 +100,9 @@ class MultiPageMainWindow(QMainWindow):
             self.tab.currentWidget().populateKillPage()
         elif tabIndex == 2:
             self.tab.currentWidget().populateSharePage()
-        elif tabIndex == 4:#TODO. Remember to update this when adding new tabs
+        elif tabIndex == 3:
+            self.tab.currentWidget().populateSharePage()
+        elif tabIndex == 4:
             self.tab.currentWidget().populateLicensePage()
         elif tabIndex == 5:
             self.tab.currentWidget().populateMaintenancePage()

--- a/desktopApp/Jahtirekisteri.py
+++ b/desktopApp/Jahtirekisteri.py
@@ -19,6 +19,7 @@ from tabs.shareTabWidget import Ui_shareTabWidget
 from tabs.killTabWidget import Ui_killTabWidget
 from tabs.licenseTabWidget import Ui_licenseTabWidget
 from tabs.maintenanceTabWidget import Ui_maintenanceTabWidget
+from tabs.shareMemberTabWidget import Ui_shareMemberTabWidget
 
 # CLASS DEFINITIONS FOR THE APP
 # -----------------------------
@@ -39,6 +40,7 @@ class MultiPageMainWindow(QMainWindow):
         self.tab.addTab(Ui_summaryTabWidget(), 'Yhteenveto')
         self.tab.addTab(Ui_killTabWidget(), 'Kaato')
         self.tab.addTab(Ui_shareTabWidget(), 'Lihanjako')
+        self.tab.addTab(Ui_shareMemberTabWidget(), 'Jako jäsenille')
         self.tab.addTab(Ui_licenseTabWidget(), 'Luvat')
         self.tab.addTab(Ui_maintenanceTabWidget(), 'Ylläpito')
 
@@ -98,9 +100,9 @@ class MultiPageMainWindow(QMainWindow):
             self.tab.currentWidget().populateKillPage()
         elif tabIndex == 2:
             self.tab.currentWidget().populateSharePage()
-        elif tabIndex == 3:
+        elif tabIndex == 4:#TODO. Remember to update this when adding new tabs
             self.tab.currentWidget().populateLicensePage()
-        elif tabIndex == 4:
+        elif tabIndex == 5:
             self.tab.currentWidget().populateMaintenancePage()
 
     def openManualDialog(self):

--- a/desktopApp/dialogs/addDialogues/Membership.py
+++ b/desktopApp/dialogs/addDialogues/Membership.py
@@ -15,7 +15,6 @@ class Membership(DialogFrame):
     # Constructor
     def __init__(self):
 
-        # TODO: set current day as default
         super().__init__()
 
         loadUi("ui/addMembershipDialog.ui", self)
@@ -26,20 +25,24 @@ class Membership(DialogFrame):
         self.connectionArguments = databaseOperationConnections.readDatabaseSettingsFromFile('connectionSettings.dat')
 
         # Elements
-        self.membershipMemberCB = self.membershipMemberComboBox
-        self.membershipGroupCB = self.membershipGroupComboBox
-        self.membershipShareSB = self.membershipShareSpinBox
-        self.membershipJoinDE = self.membershipJoinDateEdit
+        self.membershipMemberCB: QComboBox = self.membershipMemberComboBox
+        self.membershipGroupCB: QComboBox = self.membershipGroupComboBox
+        self.membershipShareSB: QSpinBox = self.membershipShareSpinBox
+        self.membershipJoinDE: QDateEdit = self.membershipJoinDateEdit
+        self.membershipJoinDE.setDate(self.currentDate) # Set current date as default
+        self.membershipPartyCB: QComboBox = self.membershipPartyComboBox
+        self.membershipPartyCB.currentIndexChanged.connect(self.handlePartyCBChange)
 
-        self.membershipAddPushBtn = self.membershipAddPushButton
+        self.membershipAddPushBtn: QPushButton = self.membershipAddPushButton
         self.membershipAddPushBtn.clicked.connect(self.addMembership) # Signal
-        self.membershipCancelPushBtn = self.membershipCancelPushButton
+        self.membershipCancelPushBtn: QPushButton = self.membershipCancelPushButton
         self.membershipCancelPushBtn.clicked.connect(self.closeDialog) # Signal
 
         self.populateAddMembershipDialog()
     
     def populateAddMembershipDialog(self):
-        self.membershipJoinDE.setDate(self.currentDate)
+        """Method for populating the dialog windows combo boxes with data from the database
+        """
 
         databaseOperation1 = pgModule.DatabaseOperation()
         databaseOperation1.getAllRowsFromTable(
@@ -68,29 +71,59 @@ class Membership(DialogFrame):
         else:
             self.groupIdList = prepareData.prepareComboBox(
                 databaseOperation2, self.membershipGroupCB, 2, 0)
-
-
+            
+        databaseOperation3 = pgModule.DatabaseOperation()
+        databaseOperation3.getAllRowsFromTable(
+            self.connectionArguments, 'public.seurue')
+        if databaseOperation3.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation3.errorMessage,
+                databaseOperation3.detailedMessage
+            )
+        else:
+            self.partyIdList = prepareData.prepareComboBox(
+                databaseOperation3, self.membershipPartyCB, 2, 0)
+            
+            # Save the party type data to the combo box items
+            for i in range(len(self.partyIdList)):
+                self.membershipPartyCB.setItemData(i, databaseOperation3.resultSet[i][4])
+        
+            # Call the method to handle the change of the combo box
+            self.handlePartyCBChange()
 
 
     def addMembership(self):
+        """Method for adding membership to the database when the push button is clicked on interface
+        """
+        
+        # Read the data from the widgets and generate SQL clause based on them
         try:
             share = self.membershipShareSB.value()
             memberChosenItemIx = self.membershipMemberCB.currentIndex()
             memberId = self.memberIdList[memberChosenItemIx]
+            partyChosenItemIx = self.membershipPartyCB.currentIndex()
+            partyId = self.partyIdList[partyChosenItemIx]
             groupChosenItemIx = self.membershipGroupCB.currentIndex()
             groupId = self.groupIdList[groupChosenItemIx]
             joinDate = self.membershipJoinDE.date().toPyDate()
 
-            sqlClauseBeginning = "INSERT INTO public.jasenyys(ryhma_id, jasen_id, liittyi, osuus) VALUES("
-            sqlClauseValues = f"{groupId}, {memberId}, '{joinDate}', {share}"
+            # Check if the party is group type or not and create SQL clause accordingly
+            if self.membershipGroupCB.isEnabled():
+                sqlClauseBeginning = "INSERT INTO public.jasenyys(ryhma_id, jasen_id, liittyi, osuus, seurue_id) VALUES("
+                sqlClauseValues = f"{groupId}, {memberId}, '{joinDate}', {share}, {partyId}"
+            else:
+                sqlClauseBeginning = "INSERT INTO public.jasenyys(jasen_id, liittyi, osuus, seurue_id) VALUES("
+                sqlClauseValues = f"{memberId}, '{joinDate}', {share}, {partyId}"
+            
             sqlClauseEnd = ");"
             sqlClause = sqlClauseBeginning + sqlClauseValues + sqlClauseEnd
-
 
         except:
             self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
 
-        # create DatabaseOperation object to execute the SQL clause
+        # Create DatabaseOperation object to execute the SQL clause
         databaseOperation = pgModule.DatabaseOperation()
         databaseOperation.insertRowToTable(self.connectionArguments, sqlClause)
         if databaseOperation.errorCode != 0:
@@ -104,6 +137,16 @@ class Membership(DialogFrame):
             # Update the page to show new data and clear 
             success = SuccessfulOperationDialog()
             success.exec()
+
+    def handlePartyCBChange(self):
+        """
+        Method for handling the change of the party combo box and 
+        setting the group combo box enabled or disabled based on the party type
+        """
+        if self.membershipPartyCB.currentData() == 2:
+            self.membershipGroupCB.setEnabled(False)
+        else:
+            self.membershipGroupCB.setEnabled(True)
 
     def closeDialog(self):
         self.close()

--- a/desktopApp/dialogs/editDialogues/Party.py
+++ b/desktopApp/dialogs/editDialogues/Party.py
@@ -15,6 +15,10 @@ import prepareData as prepareData
 from datetime import date
 
 class Party(DialogFrame):
+    """
+        Dialog for editing party information
+    """
+    
     def __init__(self):
 
         super().__init__()
@@ -27,22 +31,29 @@ class Party(DialogFrame):
         self.setWindowTitle('Muokkaa seurue tietoja')
         
         # Elements
-        self.editPartyCB = self.editPartyComboBox
-        self.editPartyNameLE = self.editPartyNameLineEdit
-        self.editPartyLeaderCB = self.editPartyLeaderComboBox
-        self.editPartyPopulatePushBtn = self.editPartyPopulatePushButton
+        self.editPartyCB: QComboBox = self.editPartyComboBox
+        self.editPartyCB.currentIndexChanged.connect(self.hadlePartyCBChange)
+        self.editPartyNameLE: QLineEdit = self.editPartyNameLineEdit
+        self.editPartyLeaderCB: QComboBox = self.editPartyLeaderComboBox
+        self.editPartyTypeCB: QComboBox = self.editPartyTypeComboBox
+        
+        self.editPartyPopulatePushBtn: QPushButton = self.editPartyPopulatePushButton
         self.editPartyPopulatePushBtn.clicked.connect(self.populateFields)
-        self.editPartyCancelPushBtn = self.editPartyCancelPushButton
+        
+        self.editPartyCancelPushBtn: QPushButton = self.editPartyCancelPushButton
         self.editPartyCancelPushBtn.clicked.connect(self.closeDialog)
-        self.editPartySavePushBtn = self.editPartySavePushButton
+        
+        self.editPartySavePushBtn: QPushButton = self.editPartySavePushButton
+        self.editPartySavePushBtn.setEnabled(False)
         self.editPartySavePushBtn.clicked.connect(self.editParty)
-
-        # State to track whether user has selected member to edit
-        self.state = -1
 
         self.populatePartyCB()
 
     def populatePartyCB(self):
+        """
+            Method for populating the widgets of the dialog
+        """
+        
         databaseOperation1 = pgModule.DatabaseOperation()
         databaseOperation1.getAllRowsFromTable(
             self.connectionArguments, 'public.seurue')
@@ -56,7 +67,16 @@ class Party(DialogFrame):
         else:
             self.partyIdList = prepareData.prepareComboBox(
                 databaseOperation1, self.editPartyCB, 2, 0)
+            
+            # Save the data of the parties to the combo box items
+            # as QCobmoBox has a method of storing data to the items
+            for i in range(len(self.partyIdList)):
+                self.editPartyCB.setItemData(i, databaseOperation1.resultSet[i])
+            
+            # Call the method to handle the change of the combo box
+            self.hadlePartyCBChange()
 
+        # Populate party leader combo box
         databaseOperation2 = pgModule.DatabaseOperation()
         databaseOperation2.getAllRowsFromTable(
             self.connectionArguments, 'public.nimivalinta')
@@ -70,12 +90,114 @@ class Party(DialogFrame):
         else:
             self.memberIdList = prepareData.prepareComboBox(
                 databaseOperation2, self.editPartyLeaderCB, 1, 0)
+            
+            # Save the data of the members to the combo box items
+            for i in range(len(self.memberIdList)):
+                self.editPartyLeaderCB.setItemData(i, self.memberIdList[i])
+            
+        # Populate party type combo box
+        databaseOperation3 = pgModule.DatabaseOperation()
+        databaseOperation3.getAllRowsFromTable(
+            self.connectionArguments, 'public.seurue_tyyppi')
+        if databaseOperation3.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation3.errorMessage,
+                databaseOperation3.detailedMessage
+                )
+        else:
+            self.partyTypeList = prepareData.prepareComboBox(
+                databaseOperation3, self.editPartyTypeCB, 1, 0)
+            
+            # Save the data of the party types to the combo box items
+            for i in range(len(self.partyTypeList)):
+                self.editPartyTypeCB.setItemData(i, self.partyTypeList[i])
+        
     
-    # Finish populateFields, editParty, closeDialog methods
     def populateFields(self):
+        """
+            Method for populating the fields of the dialog
+            based on the chosen party
+        """
+        
+        try:
+            # Save data for later use
+            self.chosenParty = self.tempDataDict
+            
+            # Set the data from the chosen party to the fields
+            self.editPartyNameLE.setText(self.chosenParty['seurueen_nimi'])
+            
+            # Find the index of the chosen party leader from the combo box
+            # and set the combo box to that index
+            memberCBIx = self.editPartyLeaderCB.findData(self.chosenParty['jasen_id'])
+            self.editPartyLeaderCB.setCurrentIndex(memberCBIx)
+            
+            # Find the index of the chosen party type from the combo box
+            # and set the combo box to that index
+            typeCBIx = self.editPartyTypeCB.findData(self.chosenParty['seurue_tyyppi_id'])
+            self.editPartyTypeCB.setCurrentIndex(typeCBIx)
+            
+            # Enable the save button
+            self.editPartySavePushBtn.setEnabled(True)
+        except Exception as e:
+            self.alert(
+                'Vakava virhe',
+                'Kenttien täydennys epäonnistui',
+                str(e),
+                '-'
+                )
+        
+        
+    def hadlePartyCBChange(self):
+        """
+            Method for handling the change of the party combo box
+            and saving the data of the current party to a temporary dictionary
+        """
+        
+        # Initial render of the dialog, the combo box is empty and to avoid errors
+        # we need to check if the combo box has any data
+        if self.editPartyCB.currentData() == None:
+            return
+        
+        self.tempDataDict = {
+            "seurue_id": self.editPartyCB.currentData()[0],
+            "seura_id": self.editPartyCB.currentData()[1],
+            "seurueen_nimi": self.editPartyCB.currentData()[2],
+            "jasen_id": self.editPartyCB.currentData()[3],
+            "seurue_tyyppi_id": self.editPartyCB.currentData()[4]
+        }
+                
+
+    def editParty(self):
+        """
+            Method for editing party information when the save button is clicked
+        """
+        
+        try:
+            # Create a dictionary of the values to be updated
+            editToSave = {
+                "seurueen_nimi": self.editPartyNameLE.text(),
+                "jasen_id": self.editPartyLeaderCB.currentData(),
+                "seurue_tyyppi_id": self.editPartyTypeCB.currentData()
+            }
+            
+            # Create a string of the columns and values to be updated
+            # from the dictionary above
+            columnValueString = ""
+            for key, value in editToSave.items():
+                columnValueString += f"{key} = {value!r}"
+                if key != "seurue_tyyppi_id":
+                    columnValueString += ", "
+                
+            
+            table = 'public.seurue'
+            limit = f"public.seurue.seurue_id = {self.chosenParty['seurue_id']}"
+        except:
+            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
+
         databaseOperation = pgModule.DatabaseOperation()
-        databaseOperation.getAllRowsFromTable(
-            self.connectionArguments, 'public.seurue_jasen_nimella')
+        databaseOperation.updateManyValuesInRow(self.connectionArguments, table, columnValueString, limit)
         if databaseOperation.errorCode != 0:
             self.alert(
                 'Vakava virhe',
@@ -83,99 +205,12 @@ class Party(DialogFrame):
                 databaseOperation.errorMessage,
                 databaseOperation.detailedMessage
                 )
-        else:
-            if databaseOperation.resultSet != []:
-                partyChosenItemIx = self.editPartyCB.currentIndex()
-                partyId = self.partyIdList[partyChosenItemIx]
-
-
-                partyList = databaseOperation.resultSet
-                index = -1
-                i = 0
-                for party in partyList:
-                    if party[0] == partyId:
-                        index = i
-                    i += 1
-
-                self.party = partyList[index]
-                self.uneditedData = (self.party[1], self.party[2])
-                
-                memberCBIx = self.editPartyLeaderCB.findText(self.party[3], Qt.MatchFixedString)
-                if memberCBIx >= 0:
-                    self.editPartyLeaderCB.setCurrentIndex(memberCBIx)
-                else:
-                    self.alert(
-                        'Vakava virhe',
-                        'Jäsentä ei löytynyt valikosta',
-                        '-',
-                        '-'
-                        )
-                    return
-
-                self.state = 0
-                self.editPartyNameLE.setText(self.party[1])
-                
-
-    def editParty(self):
-        errorCode = 0
-        if self.state == -1:
-            self.alert(
-                'Vakava virhe',
-                'Et ole valinnut muokattaavaa seuruetta',
-                'Valitse seurue valikosta ja paina täytä painiketta',
-                '-'
-                )
             return
-        try:
-            memberChosenItemIx = self.editPartyLeaderCB.currentIndex()
-            memberId = self.memberIdList[memberChosenItemIx]
-
-            updateList = (
-                self.editPartyNameLE.text(),
-                memberId
-            )
-
-            for item in updateList:
-                    if item == '':
-                        errorCode = 1
-
-            columnList = [
-                'seurueen_nimi',
-                'jasen_id'
-            ]
-            table = 'public.seurue'
-            limit = f"public.seurue.seurue_id = {self.party[0]}"
-        except:
-            self.alert('Virheellinen syöte', 'Tarkista antamasi tiedot', 'Jotain meni pieleen','hippopotamus' )
-        
-        if errorCode == 1:
-                self.alert(
-                'Vakava virhe',
-                'Et voi päivittää tyhjää kenttää',
-                'Täytä tyhjät kentät päivittääksesi seureen tietoja',
-                '-'
-                )
-                return
-
-        i = 0
-        for data in updateList:
-            if data != self.uneditedData[i]:
-                databaseOperation = pgModule.DatabaseOperation()
-                databaseOperation.updateTable(self.connectionArguments, table,
-                columnList[i], f"{data!r}", limit)
-                if databaseOperation.errorCode != 0:
-                    self.alert(
-                        'Vakava virhe',
-                        'Tietokantaoperaatio epäonnistui',
-                        databaseOperation.errorMessage,
-                        databaseOperation.detailedMessage
-                        )
-            i += 1
         
         success = SuccessfulOperationDialog()
         success.exec()
         self.editPartyNameLE.clear()
-        self.state = -1
+        self.editPartySavePushBtn.setEnabled(False)
         self.populatePartyCB()
 
     def closeDialog(self):

--- a/desktopApp/tabs/shareMemberTabWidget.py
+++ b/desktopApp/tabs/shareMemberTabWidget.py
@@ -16,7 +16,6 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
     def __init__(self):
         super(Ui_shareMemberTabWidget, self).__init__()
         loadUi('ui/shareMemberTab.ui', self)
-        #TODO: Do everything lol
     
         self.currentDate = date.today()
 
@@ -24,6 +23,9 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
         self.shareDE: QDateEdit = self.shareDateEdit
         self.sharePortionCB: QComboBox = self.portionComboBox
         self.shareMemberCB: QComboBox = self.memberComboBox
+        self.sharePartyCB: QComboBox = self.partyComboBox
+        self.sharePartyCB.currentIndexChanged.connect(self.handlePartyCBChange)
+        
         self.shareSavePushBtn: QPushButton = self.shareSavePushButton
         self.shareSavePushBtn.clicked.connect(self.saveShare) # Signal
         self.sharedPortionsTW: QTableWidget = self.shareSharedPortionsTableWidget
@@ -93,21 +95,6 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
             self.sharePortionText = prepareData.prepareComboBox(
                 databaseOperation2, self.sharePortionCB, 0, 0)
         
-        # Prepare portion combo box
-        databaseOperation3 = pgModule.DatabaseOperation()
-        databaseOperation3.getAllRowsFromTable(
-            self.connectionArguments, 'public.nimivalinta')
-        if databaseOperation3.errorCode != 0:
-            self.alert(
-                'Vakava virhe',
-                'Tietokantaoperaatio epäonnistui',
-                databaseOperation3.errorMessage,
-                databaseOperation3.detailedMessage
-                )
-        else:
-            self.shareMemberIdList = prepareData.prepareComboBox(
-                databaseOperation3, self.shareMemberCB, 1, 0)
-        
         # Prepare the shared portions table
         databaseOperation4 = pgModule.DatabaseOperation()
         databaseOperation4.getAllRowsFromTable(
@@ -121,7 +108,6 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
                 )
         else:
             try:
-                print("moi")
                 # parse the data from the view to readable format
                 tableData = prepareData.parseSharedPortionOfShot(databaseOperation4.resultSet)
                 
@@ -140,6 +126,38 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
                 'Oops'
             )
             
+        
+        databaseOperation5 = pgModule.DatabaseOperation()
+        databaseOperation5.getAllRowsFromTableWithLimit(
+            self.connectionArguments, 'public.seurue', 'seurue_tyyppi_id = 2')
+        if databaseOperation5.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation5.errorMessage,
+                databaseOperation5.detailedMessage
+                )
+        else:
+            self.sharePartyText = prepareData.prepareComboBox(
+                databaseOperation5, self.sharePartyCB, 2, 0)
+            
+            for i in range(len(self.sharePartyText)):
+                self.sharePartyCB.setItemData(i, databaseOperation5.resultSet[i])
+                
+        databaseOperation6 = pgModule.DatabaseOperation()
+        databaseOperation6.getAllRowsFromTable(
+            self.connectionArguments, 'public.jasenyys_nimella')
+        if databaseOperation6.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation6.errorMessage,
+                databaseOperation6.detailedMessage
+                )
+        else:
+            self.membershipData = databaseOperation6.resultSet
+            self.handlePartyCBChange()
+        
         
         # Set the chosen shot label to empty
         self.chosenItemLbl.setText("Ei valittua kaatoa")
@@ -176,12 +194,11 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
             shareDay = self.shareDE.date().toPyDate()
             portion = self.sharePortionCB.currentText()
             weight = portionDict[portion] * self.shotWeight
-            shareMemberChosenItemIx = self.shareMemberCB.currentIndex()
-            shareMemberId = self.shareMemberIdList[shareMemberChosenItemIx]
+            shareMembership = self.shareMemberCB.currentData()
             
             # Create SQL query
-            sqlClauseBeginning = f"INSERT INTO public.jakotapahtuma_jasen(paiva, kaadon_kasittely_id, osnimitys, jasen_id, maara) VALUES("
-            sqlClauseValues = f"'{shareDay}', {shotUsageId!r}, {portion!r}, {shareMemberId!r}, {weight!r}"
+            sqlClauseBeginning = f"INSERT INTO public.jakotapahtuma_jasen(paiva, kaadon_kasittely_id, osnimitys, jasenyys_id, maara) VALUES("
+            sqlClauseValues = f"'{shareDay}', {shotUsageId!r}, {portion!r}, {shareMembership!r}, {weight!r}"
             sqlClauseEnd = ");"
             
             # Assemble the query
@@ -210,4 +227,17 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
             self.populateSharePage()
             self.shareSavePushBtn.setEnabled(False)
    
-         
+    def handlePartyCBChange(self):
+        """Method for handling the change event on the party combo box
+        """
+        if self.sharePartyCB.currentData() == None:
+            return
+        
+        currentPartyId = self.sharePartyCB.currentData()[0]
+        
+        self.shareMemberCB.clear()
+        
+        for i, item in enumerate(self.membershipData):
+            if item[2] == currentPartyId:
+                # (member name, membership id)
+                self.shareMemberCB.addItem(item[1], item[0])

--- a/desktopApp/tabs/shareMemberTabWidget.py
+++ b/desktopApp/tabs/shareMemberTabWidget.py
@@ -20,7 +20,7 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
     
         self.currentDate = date.today()
 
-        self.shareKillsMemberTW: QTableWidget= self.shareKillsTableWidget
+        self.shareKillsMemberTW: QTableWidget = self.shareKillsTableWidget
         self.shareDE: QDateEdit = self.shareDateEdit
         self.sharePortionCB: QComboBox = self.portionComboBox
         self.shareMemberCB: QComboBox = self.memberComboBox
@@ -33,7 +33,7 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
         self.shareSankeyWebView: QWebEngineView = self.shareSankeyWebEngineView
 
         # Signal when the user clicks an item on shareKillsTW
-        # self.shareKillsMemberTW.itemClicked.connect(self.onShareKillTableClick)
+        self.shareKillsMemberTW.itemClicked.connect(self.onShareKillTableClick)
 
                 # Read database connection arguments from the settings file
         try:
@@ -146,3 +146,16 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
         
         # Disable the save button
         self.shareSavePushBtn.setEnabled(False)
+    
+    def onShareKillTableClick(self, item: QTableWidgetItem):
+        """Method for handling the click event on the table
+
+        Args:
+            item (QTableWidgetItem): Item clicked in the table
+        """
+        selectedRow = item.row()
+        self.shotUsageId = int(self.shareKillsMemberTW.item(selectedRow, 10).text())
+        self.shotWeight = float(self.shareKillsMemberTW.item(selectedRow, 9).text())
+        self.chosenItemLbl.setText(f"Valittu Kaato ID: {self.shareKillsMemberTW.item(selectedRow, 0).text()}")
+        self.shareSavePushBtn.setEnabled(True)
+           

--- a/desktopApp/tabs/shareMemberTabWidget.py
+++ b/desktopApp/tabs/shareMemberTabWidget.py
@@ -44,7 +44,7 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
             databaseOperation = pgModule.DatabaseOperation()
             self.connectionArguments = databaseOperation.readDatabaseSettingsFromFile('connectionSettings.dat')
 
-        # self.populateSharePage()
+        self.populateSharePage()
         
     def alert(self, windowTitle, alertMsg, additionalMsg, details):
         """Creates a message box for critical errors
@@ -64,3 +64,85 @@ class Ui_shareMemberTabWidget(QScrollArea, QWidget):
         alertDialog.setDetailedText(details) # Technical details in English (from psycopg2)
         alertDialog.setStandardButtons(QMessageBox.Ok) # Only OK is needed to close the dialog
         alertDialog.exec_() # Open the message box
+    
+    def populateSharePage(self):
+        databaseOperation1 = pgModule.DatabaseOperation()
+        databaseOperation1.getAllRowsFromTable(self.connectionArguments, 'public.jako_kaadot_jasenille')
+        if databaseOperation1.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation1.errorMessage,
+                databaseOperation1.detailedMessage
+                )
+        else:
+            self.shareKillIdList = prepareData.prepareTable(databaseOperation1, self.shareKillsMemberTW)
+
+        # Read data fom table ruhonosa and populate the combo box
+        databaseOperation2 = pgModule.DatabaseOperation()
+        databaseOperation2.getAllRowsFromTable(
+            self.connectionArguments, 'public.ruhonosa')
+        if databaseOperation2.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation2.errorMessage,
+                databaseOperation2.detailedMessage
+                )
+        else:
+            self.sharePortionText = prepareData.prepareComboBox(
+                databaseOperation2, self.sharePortionCB, 0, 0)
+        
+        # Prepare portion combo box
+        databaseOperation3 = pgModule.DatabaseOperation()
+        databaseOperation3.getAllRowsFromTable(
+            self.connectionArguments, 'public.nimivalinta')
+        if databaseOperation3.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation3.errorMessage,
+                databaseOperation3.detailedMessage
+                )
+        else:
+            self.shareMemberIdList = prepareData.prepareComboBox(
+                databaseOperation3, self.shareMemberCB, 1, 0)
+        
+        # Prepare the shared portions table
+        databaseOperation4 = pgModule.DatabaseOperation()
+        databaseOperation4.getAllRowsFromTable(
+            self.connectionArguments, 'public.jaetut_ruhon_osat_jasenille')
+        if databaseOperation4.errorCode != 0:
+            self.alert(
+                'Vakava virhe',
+                'Tietokantaoperaatio epäonnistui',
+                databaseOperation4.errorMessage,
+                databaseOperation4.detailedMessage
+                )
+        else:
+            try:
+                print("moi")
+                # parse the data from the view to readable format
+                tableData = prepareData.parseSharedPortionOfShot(databaseOperation4.resultSet)
+                
+                # Set row count and column headers to match the data
+                databaseOperation4.rows = len(tableData)
+                databaseOperation4.columnHeaders[2] = 'Jaettu'
+                databaseOperation4.resultSet = tableData
+                
+                prepareData.prepareTable(databaseOperation4, self.sharedPortionsTW)
+                self.sharedPortionsTW.setColumnHidden(4, True)
+            except:
+                self.alert(
+                'Vakava virhe',
+                'Jaetut taulukon luonti epäonnistui',
+                'Shared kills failed to load on share page',
+                'Oops'
+            )
+            
+        
+        # Set the chosen shot label to empty
+        self.chosenItemLbl.setText("Ei valittua kaatoa")
+        
+        # Disable the save button
+        self.shareSavePushBtn.setEnabled(False)

--- a/desktopApp/tabs/shareMemberTabWidget.py
+++ b/desktopApp/tabs/shareMemberTabWidget.py
@@ -1,0 +1,66 @@
+from PyQt5.QtWidgets import (QWidget, QScrollArea, QMessageBox, QTableWidget, 
+                             QTableWidgetItem, QDateEdit, QComboBox, QPushButton, QLabel)
+from PyQt5 import QtCore
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt5.uic import loadUi
+from datetime import date
+import pgModule
+import prepareData
+import figures
+import party
+
+import dialogs.dialogueWindow as dialogueWindow
+
+
+class Ui_shareMemberTabWidget(QScrollArea, QWidget):
+    def __init__(self):
+        super(Ui_shareMemberTabWidget, self).__init__()
+        loadUi('ui/shareMemberTab.ui', self)
+        #TODO: Do everything lol
+    
+        self.currentDate = date.today()
+
+        self.shareKillsMemberTW: QTableWidget= self.shareKillsTableWidget
+        self.shareDE: QDateEdit = self.shareDateEdit
+        self.sharePortionCB: QComboBox = self.portionComboBox
+        self.shareMemberCB: QComboBox = self.memberComboBox
+        self.shareSavePushBtn: QPushButton = self.shareSavePushButton
+        # self.shareSavePushBtn.clicked.connect(self.saveShare) # Signal
+        self.sharedPortionsTW: QTableWidget = self.shareSharedPortionsTableWidget
+
+        self.chosenItemLbl: QLabel = self.chosenItemLabel
+
+        self.shareSankeyWebView: QWebEngineView = self.shareSankeyWebEngineView
+
+        # Signal when the user clicks an item on shareKillsTW
+        # self.shareKillsMemberTW.itemClicked.connect(self.onShareKillTableClick)
+
+                # Read database connection arguments from the settings file
+        try:
+            databaseOperation = pgModule.DatabaseOperation()
+            self.connectionArguments = databaseOperation.readDatabaseSettingsFromFile('connectionSettings.dat')
+        except:
+            self.openSettingsDialog()
+            databaseOperation = pgModule.DatabaseOperation()
+            self.connectionArguments = databaseOperation.readDatabaseSettingsFromFile('connectionSettings.dat')
+
+        # self.populateSharePage()
+        
+    def alert(self, windowTitle, alertMsg, additionalMsg, details):
+        """Creates a message box for critical errors
+
+        Args:
+            windowTitle (str): Title of the message box
+            alertMsg (str): Basic information about the error in Finnish
+            additionalMsg (str): Additional information about the error in Finnish
+            details (str): Technical details in English (from psycopg2)
+        """
+
+        alertDialog = QMessageBox() # Create a message box object
+        alertDialog.setWindowTitle(windowTitle) # Add appropriate title to the message box
+        alertDialog.setIcon(QMessageBox.Critical) # Set icon to critical
+        alertDialog.setText(alertMsg) # Basic information about the error in Finnish
+        alertDialog.setInformativeText(additionalMsg) # Additional information about the error in Finnish
+        alertDialog.setDetailedText(details) # Technical details in English (from psycopg2)
+        alertDialog.setStandardButtons(QMessageBox.Ok) # Only OK is needed to close the dialog
+        alertDialog.exec_() # Open the message box

--- a/desktopApp/ui/addMembershipDialog.ui
+++ b/desktopApp/ui/addMembershipDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>450</width>
     <height>223</height>
    </rect>
   </property>
@@ -39,8 +39,8 @@
   <widget class="QDateEdit" name="membershipJoinDateEdit">
    <property name="geometry">
     <rect>
-     <x>210</x>
-     <y>100</y>
+     <x>310</x>
+     <y>50</y>
      <width>110</width>
      <height>22</height>
     </rect>
@@ -49,8 +49,8 @@
   <widget class="QLabel" name="membershipJoinLabel">
    <property name="geometry">
     <rect>
-     <x>210</x>
-     <y>80</y>
+     <x>310</x>
+     <y>30</y>
      <width>91</width>
      <height>16</height>
     </rect>
@@ -63,7 +63,7 @@
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>50</y>
+     <y>110</y>
      <width>171</width>
      <height>22</height>
     </rect>
@@ -73,8 +73,8 @@
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>30</y>
-     <width>47</width>
+     <y>90</y>
+     <width>70</width>
      <height>13</height>
     </rect>
    </property>
@@ -85,8 +85,8 @@
   <widget class="QLabel" name="membershipShareLabel">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>80</y>
+     <x>210</x>
+     <y>30</y>
      <width>47</width>
      <height>13</height>
     </rect>
@@ -127,8 +127,8 @@
   <widget class="QSpinBox" name="membershipShareSpinBox">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>100</y>
+     <x>210</x>
+     <y>50</y>
      <width>80</width>
      <height>22</height>
     </rect>
@@ -141,6 +141,29 @@
    </property>
    <property name="value">
     <number>100</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="membershipGroupLabel_2">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>90</y>
+     <width>60</width>
+     <height>13</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Seurue</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="membershipPartyComboBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>110</y>
+     <width>171</width>
+     <height>22</height>
+    </rect>
    </property>
   </widget>
  </widget>

--- a/desktopApp/ui/addPartyDialog.ui
+++ b/desktopApp/ui/addPartyDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>324</width>
+    <width>534</width>
     <height>177</height>
    </rect>
   </property>
@@ -86,6 +86,29 @@
    </property>
    <property name="text">
     <string>Lisää</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="addPartyTypeComboBox">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>50</y>
+     <width>130</width>
+     <height>22</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>30</y>
+     <width>130</width>
+     <height>13</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Seurueen tyyppi</string>
    </property>
   </widget>
  </widget>

--- a/desktopApp/ui/editMembershipDialog.ui
+++ b/desktopApp/ui/editMembershipDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>697</width>
-    <height>528</height>
+    <height>554</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,7 @@
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>360</y>
+     <y>400</y>
      <width>110</width>
      <height>22</height>
     </rect>
@@ -39,8 +39,8 @@
   <widget class="QLabel" name="label_2">
    <property name="geometry">
     <rect>
-     <x>30</x>
-     <y>290</y>
+     <x>160</x>
+     <y>330</y>
      <width>60</width>
      <height>13</height>
     </rect>
@@ -52,8 +52,8 @@
   <widget class="QLabel" name="label_3">
    <property name="geometry">
     <rect>
-     <x>160</x>
-     <y>290</y>
+     <x>30</x>
+     <y>280</y>
      <width>60</width>
      <height>13</height>
     </rect>
@@ -66,7 +66,7 @@
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>340</y>
+     <y>380</y>
      <width>60</width>
      <height>13</height>
     </rect>
@@ -79,7 +79,7 @@
    <property name="geometry">
     <rect>
      <x>160</x>
-     <y>360</y>
+     <y>400</y>
      <width>110</width>
      <height>22</height>
     </rect>
@@ -89,7 +89,7 @@
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>410</y>
+     <y>450</y>
      <width>42</width>
      <height>22</height>
     </rect>
@@ -108,7 +108,7 @@
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>390</y>
+     <y>430</y>
      <width>60</width>
      <height>13</height>
     </rect>
@@ -121,7 +121,7 @@
    <property name="geometry">
     <rect>
      <x>30</x>
-     <y>450</y>
+     <y>490</y>
      <width>75</width>
      <height>23</height>
     </rect>
@@ -137,7 +137,7 @@
    <property name="geometry">
     <rect>
      <x>120</x>
-     <y>450</y>
+     <y>490</y>
      <width>75</width>
      <height>23</height>
     </rect>
@@ -149,8 +149,8 @@
   <widget class="QComboBox" name="editMembershipGroupComboBox">
    <property name="geometry">
     <rect>
-     <x>30</x>
-     <y>310</y>
+     <x>160</x>
+     <y>350</y>
      <width>110</width>
      <height>22</height>
     </rect>
@@ -159,8 +159,8 @@
   <widget class="QComboBox" name="editMembershipMemberComboBox">
    <property name="geometry">
     <rect>
-     <x>160</x>
-     <y>310</y>
+     <x>30</x>
+     <y>300</y>
      <width>110</width>
      <height>22</height>
     </rect>
@@ -193,13 +193,36 @@
    <property name="geometry">
     <rect>
      <x>160</x>
-     <y>340</y>
+     <y>380</y>
      <width>70</width>
      <height>17</height>
     </rect>
    </property>
    <property name="text">
     <string>Poistuu</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_5">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>330</y>
+     <width>60</width>
+     <height>13</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Seurue</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="editMembershipPartyComboBox">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>350</y>
+     <width>110</width>
+     <height>22</height>
+    </rect>
    </property>
   </widget>
  </widget>

--- a/desktopApp/ui/editPartyDialog.ui
+++ b/desktopApp/ui/editPartyDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>321</width>
+    <width>527</width>
     <height>183</height>
    </rect>
   </property>
@@ -87,7 +87,7 @@
     <rect>
      <x>30</x>
      <y>70</y>
-     <width>80</width>
+     <width>100</width>
      <height>13</height>
     </rect>
    </property>
@@ -100,7 +100,7 @@
     <rect>
      <x>160</x>
      <y>70</y>
-     <width>90</width>
+     <width>110</width>
      <height>13</height>
     </rect>
    </property>
@@ -119,6 +119,29 @@
    </property>
    <property name="text">
     <string>Täytä</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="editPartyTypeComboBox">
+   <property name="geometry">
+    <rect>
+     <x>298</x>
+     <y>90</y>
+     <width>120</width>
+     <height>22</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>70</y>
+     <width>110</width>
+     <height>13</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Seurueen tyyppi</string>
    </property>
   </widget>
  </widget>

--- a/desktopApp/ui/shareMemberTab.ui
+++ b/desktopApp/ui/shareMemberTab.ui
@@ -134,7 +134,7 @@
       </rect>
      </property>
     </widget>
-    <widget class="QWebEngineView" name="shareSankeyWebEngineView">
+    <widget class="QWebEngineView" name="shareSankeyWebEngineView" native="true">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -143,7 +143,7 @@
        <height>361</height>
       </rect>
      </property>
-     <property name="url">
+     <property name="url" stdset="0">
       <url>
        <string>about:blank</string>
       </url>
@@ -228,7 +228,7 @@
        </rect>
       </property>
       <property name="text">
-       <string>testi</string>
+       <string>Ei valittua kaatoa</string>
       </property>
      </widget>
     </widget>

--- a/desktopApp/ui/shareMemberTab.ui
+++ b/desktopApp/ui/shareMemberTab.ui
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>sharePage</class>
+ <widget class="QWidget" name="sharePage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>950</width>
+    <height>731</height>
+   </rect>
+  </property>
+  <widget class="QScrollArea" name="scrollArea">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>951</width>
+     <height>731</height>
+    </rect>
+   </property>
+   <property name="widgetResizable">
+    <bool>true</bool>
+   </property>
+   <widget class="QWidget" name="scrollAreaWidgetContents">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>947</width>
+      <height>727</height>
+     </rect>
+    </property>
+    <widget class="QLabel" name="shotByLabel_10">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>260</y>
+       <width>100</width>
+       <height>13</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Jakopäivä</string>
+     </property>
+    </widget>
+    <widget class="QTableWidget" name="shareSharedPortionsTableWidget">
+     <property name="geometry">
+      <rect>
+       <x>520</x>
+       <y>360</y>
+       <width>420</width>
+       <height>361</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="shotByLabel_9">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>0</y>
+       <width>80</width>
+       <height>30</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Kaadot</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="shareSavePushButton">
+     <property name="geometry">
+      <rect>
+       <x>370</x>
+       <y>310</y>
+       <width>75</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Tallenna</string>
+     </property>
+    </widget>
+    <widget class="QTableWidget" name="shareKillsTableWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>30</y>
+       <width>920</width>
+       <height>192</height>
+      </rect>
+     </property>
+     <property name="toolTip">
+      <string>Valitse kaato, jonka lihoja jaetaan</string>
+     </property>
+    </widget>
+    <widget class="QDateEdit" name="shareDateEdit">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>280</y>
+       <width>121</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="locale">
+      <locale language="Finnish" country="Finland"/>
+     </property>
+     <property name="displayFormat">
+      <string>dd.MM.yyyy</string>
+     </property>
+     <property name="calendarPopup">
+      <bool>true</bool>
+     </property>
+     <property name="date">
+      <date>
+       <year>2022</year>
+       <month>11</month>
+       <day>15</day>
+      </date>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="memberComboBox">
+     <property name="geometry">
+      <rect>
+       <x>290</x>
+       <y>280</y>
+       <width>161</width>
+       <height>22</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QWebEngineView" name="shareSankeyWebEngineView">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>370</y>
+       <width>500</width>
+       <height>361</height>
+      </rect>
+     </property>
+     <property name="url">
+      <url>
+       <string>about:blank</string>
+      </url>
+     </property>
+    </widget>
+    <widget class="QLabel" name="shotByLabel_13">
+     <property name="geometry">
+      <rect>
+       <x>290</x>
+       <y>260</y>
+       <width>61</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Jäsen</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="shotByLabel_11">
+     <property name="geometry">
+      <rect>
+       <x>150</x>
+       <y>260</y>
+       <width>110</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Ruhon osa</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="portionComboBox">
+     <property name="geometry">
+      <rect>
+       <x>150</x>
+       <y>280</y>
+       <width>121</width>
+       <height>22</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="shotByLabel_15">
+     <property name="geometry">
+      <rect>
+       <x>520</x>
+       <y>330</y>
+       <width>160</width>
+       <height>30</height>
+      </rect>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Jaetut ruhon osat</string>
+     </property>
+    </widget>
+    <widget class="QFrame" name="frame">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>230</y>
+       <width>280</width>
+       <height>21</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLabel" name="chosenItemLabel">
+      <property name="geometry">
+       <rect>
+        <x>4</x>
+        <y>0</y>
+        <width>260</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>testi</string>
+      </property>
+     </widget>
+    </widget>
+   </widget>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QWebEngineView</class>
+   <extends>QWidget</extends>
+   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/desktopApp/ui/shareMemberTab.ui
+++ b/desktopApp/ui/shareMemberTab.ui
@@ -75,8 +75,8 @@
     <widget class="QPushButton" name="shareSavePushButton">
      <property name="geometry">
       <rect>
-       <x>370</x>
-       <y>310</y>
+       <x>650</x>
+       <y>280</y>
        <width>75</width>
        <height>23</height>
       </rect>
@@ -127,7 +127,7 @@
     <widget class="QComboBox" name="memberComboBox">
      <property name="geometry">
       <rect>
-       <x>290</x>
+       <x>470</x>
        <y>280</y>
        <width>161</width>
        <height>22</height>
@@ -152,7 +152,7 @@
     <widget class="QLabel" name="shotByLabel_13">
      <property name="geometry">
       <rect>
-       <x>290</x>
+       <x>470</x>
        <y>260</y>
        <width>61</width>
        <height>16</height>
@@ -231,6 +231,29 @@
        <string>Ei valittua kaatoa</string>
       </property>
      </widget>
+    </widget>
+    <widget class="QLabel" name="shotByLabel_14">
+     <property name="geometry">
+      <rect>
+       <x>290</x>
+       <y>260</y>
+       <width>61</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Seurue</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="partyComboBox">
+     <property name="geometry">
+      <rect>
+       <x>290</x>
+       <y>280</y>
+       <width>161</width>
+       <height>22</height>
+      </rect>
+     </property>
     </widget>
    </widget>
   </widget>


### PR DESCRIPTION
Added new tab to the desktop application for sharing kills straight to the members. To achieve this there had to be made changes to the database schema. The changes are as listed:

- New table called `jakotapahtuma_jasen` was created for storing the shares

| tapahtuma_jasen_id | paiva | kaadon_kasittely_id | osnimitys | maara | jasenyys_id |
| -- | -- | -- | -- | -- | -- |
| pk of table | date of the share | id of the usage | portion of share | amount | membership getting the share |

- A table `seurue_tyyppi` was added. The id of the table is used as foreign key in the `seurue` table to select the type of the party. The idea is that there are member and group parties . In group parties memberships are given by first selecting the party to join and then selecting group of party in which they will be located. On the other hand in member parties the memberships given only to the party with no group given.

| seurue_tyyppi_id | seurue_tyyppi_nimi |
| -- | -- |
| pk of table | name of the type |

- The `jasenyys` table was altered to include `seurue_id` as foreign and `ryhma_id` made nullable to allow the idea above to work

Diagram of the altered schema:

![javaw_g9QnZ90LMt](https://github.com/eeroleppalehto/Jahtirekisteri/assets/111079111/d6ce2be6-f74f-4b31-a8ef-41a62e7ab7da)

With the changes to the `seurue` and `jasenyys` table, the associated dialogs on the maintenance tab have been updated to the current schema

## Note

With the many changes to the database schema, I added a backup of it to the `database/backups/2023-10-05/` directory of the repository.