### PR TITLE
113 add sorting methods for the tables in the maintenance tab

### DIFF
--- a/desktopApp/tabs/maintenanceTabWidget.py
+++ b/desktopApp/tabs/maintenanceTabWidget.py
@@ -7,7 +7,6 @@ import prepareData
 
 import dialogs.dialogueWindow as dialogueWindow
 
-# import dialogs.addDialogueWindow as addDialogueWindow
 import dialogs.addDialogues.Member as addDialogueWindowMember
 import dialogs.addDialogues.Membership as addDialogueWindowMembership
 import dialogs.addDialogues.Group as addDialogueWindowGroup
@@ -63,12 +62,15 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
         self.maintenanceTableCB: QComboBox = self.maintenanceComboBox
         
         self.maintenanceSortCB: QComboBox = self.maintenanceSortComboBox
+        self.maintenanceSortCB.currentIndexChanged.connect(self.sortTable)
+        
+        
 
         cbOptionsList = ["Kaikki jäsenet", "Ryhmät jäsenillä", "Seurue ryhmillä"]
 
-        self.maintenanceCB.addItems(cbOptionsList)
+        self.maintenanceTableCB.addItems(cbOptionsList)
 
-        self.maintenanceCB.currentIndexChanged.connect(self.populateMaintenancePage)
+        self.maintenanceTableCB.currentIndexChanged.connect(self.handleTableOptionChange)
 
         # Read database connection arguments from the settings file
         try:
@@ -79,7 +81,7 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
             databaseOperation = pgModule.DatabaseOperation()
             self.connectionArguments = databaseOperation.readDatabaseSettingsFromFile('connectionSettings.dat')
 
-        self.populateMaintenancePage()
+        self.handleTableOptionChange()
 
     def alert(self, windowTitle, alertMsg, additionalMsg, details):
         """Creates a message box for critical errors
@@ -107,7 +109,7 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
             "Seurue ryhmillä": "public.seurue_ryhmilla",
         }
 
-        tableToShow = optionDict[self.maintenanceCB.currentText()]
+        tableToShow = optionDict[self.maintenanceTableCB.currentText()]
 
         databaseOperation1 = pgModule.DatabaseOperation()
         databaseOperation1.getAllRowsFromTable(
@@ -120,6 +122,7 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
                 databaseOperation1.detailedMessage
                 )
         else:
+            self.maintenanceTWDatabaseOperation = databaseOperation1
             prepareData.prepareTable(databaseOperation1, self.maintenanceTW)
 
     
@@ -177,6 +180,116 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
             self.maintenanceSortCB.addItems(partyTableOptions)
         
         self.populateMaintenancePage()
+
+    def sortTable(self):
+        """
+            Sorts the table based on the current option in 
+            the choose table combo box by directing the sorting
+            to the correct method
+        """
+        
+        if self.maintenanceTableCB.currentText() == "Kaikki jäsenet":
+            self.sortMemberTable()
+        elif self.maintenanceTableCB.currentText() == "Ryhmät jäsenillä":
+            self.sortGroupTable()
+        elif self.maintenanceTableCB.currentText() == "Seurue ryhmillä":
+            self.sortPartyTable()
+    
+    def sortMemberTable(self):
+        """
+            Method for sorting the member table, when the it is selected
+            in the choose table combo box
+        """
+        
+        if self.maintenanceSortCB.currentText() == "Nimi \u2191":
+            self.maintenanceTW.sortItems(0, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Nimi \u2193":
+            self.maintenanceTW.sortItems(0, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Osoite \u2191":
+            self.maintenanceTW.sortItems(1, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Osoite \u2193":
+            self.maintenanceTW.sortItems(1, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Postinumero \u2191":
+            self.maintenanceTW.sortItems(2, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Postinumero \u2193":
+            self.maintenanceTW.sortItems(2, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Postitoimipaikka \u2191":
+            self.maintenanceTW.sortItems(3, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Postitoimipaikka \u2193":
+            self.maintenanceTW.sortItems(3, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Tila \u2191":
+            self.maintenanceTW.sortItems(4, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Tila \u2193":
+            self.maintenanceTW.sortItems(4, order=Qt.AscendingOrder)
+    
+    def sortGroupTable(self):
+        """
+            Method for sorting the group table, when the it is selected
+            in the choose table combo box
+        """
+        
+        if self.maintenanceSortCB.currentText() == "Ryhmän nimi \u2191":
+            self.maintenanceTW.sortItems(0, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Ryhmän nimi \u2193":
+            self.maintenanceTW.sortItems(0, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Nimi \u2191":
+            self.maintenanceTW.sortItems(1, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Nimi \u2193":
+            self.maintenanceTW.sortItems(1, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Liittynyt \u2191":
+            self.maintenanceTW.sortItems(2, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Liittynyt \u2193":
+            self.maintenanceTW.sortItems(2, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Poistunut \u2191":
+            self.maintenanceTW.sortItems(3, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Poistunut \u2193":
+            self.maintenanceTW.sortItems(3, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Osuus \u2191":
+            self.maintenanceTW.sortItems(4, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Osuus \u2193":
+            self.sortNumericCells(self.maintenanceTW, 4, self.maintenanceTWDatabaseOperation, True)
+    
+    def sortPartyTable(self):
+        """
+            Method for sorting the party table, when the it is selected
+            in the choose table combo box
+        """
+        
+        if self.maintenanceSortCB.currentText() == "Seurueen nimi \u2191":
+            self.maintenanceTW.sortItems(0, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Seurueen nimi \u2193":
+            self.maintenanceTW.sortItems(0, order=Qt.AscendingOrder)
+        
+        elif self.maintenanceSortCB.currentText() == "Ryhmän nimi \u2191":
+            self.maintenanceTW.sortItems(1, order=Qt.DescendingOrder)
+        elif self.maintenanceSortCB.currentText() == "Ryhmän nimi \u2193":
+            self.maintenanceTW.sortItems(1, order=Qt.AscendingOrder)
+
+    def sortNumericCells(self, tableWidget: QTableWidget, columnNumber: int, databaseOperation: pgModule.DatabaseOperation, reverse: bool):
+        """
+            As the sortItems() method does not work with numeric values,
+            we need to sort the data manually
+            
+            Args:
+                tableWidget (QTableWidget): the table widget to sort
+                columnNumber (int): the column number of the table to sort
+                databaseOperation (pgModule.DatabaseOperation): the database operation object
+                reverse (bool): reverse the order of the sort if True
+                
+        """
+        
+        databaseOperation.resultSet.sort(reverse=reverse, key=lambda x: float(x[columnNumber]))
+        
+        # Mount the data back to the TableWidget
+        prepareData.prepareTable(databaseOperation, tableWidget)
 
     #SIGNALS
     def openSettingsDialog(self):

--- a/desktopApp/tabs/maintenanceTabWidget.py
+++ b/desktopApp/tabs/maintenanceTabWidget.py
@@ -1,5 +1,6 @@
 
-from PyQt5.QtWidgets import QWidget, QScrollArea, QFrame, QVBoxLayout, QMessageBox
+from PyQt5.QtWidgets import QWidget, QScrollArea, QFrame, QVBoxLayout, QMessageBox, QPushButton, QTableWidget, QComboBox
+from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
 import pgModule
 import prepareData
@@ -29,37 +30,37 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
         super(Ui_maintenanceTabWidget, self).__init__()
         loadUi('ui/maintenanceTab.ui', self)
 
-        self.maintenanceAddMemberPushBtn = self.maintenanceAddMemberPushButton
+        self.maintenanceAddMemberPushBtn: QPushButton = self.maintenanceAddMemberPushButton
         self.maintenanceAddMemberPushBtn.clicked.connect(self.openAddMemberDialog) # Signal
-        self.maintenanceRemoveMemberPushBtn = self.maintenanceRemoveMemberPushButton
+        self.maintenanceRemoveMemberPushBtn: QPushButton = self.maintenanceRemoveMemberPushButton
         self.maintenanceRemoveMemberPushBtn.clicked.connect(self.openRemoveMemberDialog) # Signal
-        self.maintenanceAddMembershipPushBtn = self.maintenanceAddMembershipPushButton
+        self.maintenanceAddMembershipPushBtn: QPushButton = self.maintenanceAddMembershipPushButton
         self.maintenanceAddMembershipPushBtn.clicked.connect(self.openAddMembershipDialog) # Signal
-        self.maintenanceAddGroupPushBtn = self.maintenanceAddGroupPushButton
+        self.maintenanceAddGroupPushBtn: QPushButton = self.maintenanceAddGroupPushButton
         self.maintenanceAddGroupPushBtn.clicked.connect(self.openAddGroupDialog) # Signal
-        self.maintenanceRemoveGroupPushBtn = self.maintenanceRemoveGroupPushButton
+        self.maintenanceRemoveGroupPushBtn: QPushButton = self.maintenanceRemoveGroupPushButton
         self.maintenanceRemoveGroupPushBtn.clicked.connect(self.openRemoveGroupDialog) # Signal
-        self.maintenanceAddPartyPushBtn = self.maintenanceAddPartyPushButton
+        self.maintenanceAddPartyPushBtn: QPushButton = self.maintenanceAddPartyPushButton
         self.maintenanceAddPartyPushBtn.clicked.connect(self.openAddMPartyDialog) # Signal
-        self.maintenanceRemovePartyPushBtn = self.maintenanceRemovePartyPushButton
+        self.maintenanceRemovePartyPushBtn: QPushButton = self.maintenanceRemovePartyPushButton
         self.maintenanceRemovePartyPushBtn.clicked.connect(self.openRemovePartyDialog) # Signal
-        self.maintenanceEditCompanyPushBtn = self.maintenanceEditCompanyPushButton
+        self.maintenanceEditCompanyPushBtn: QPushButton = self.maintenanceEditCompanyPushButton
         self.maintenanceEditCompanyPushBtn.clicked.connect(self.openEditCompanyDialog) # Signal
-        self.maintenanceEditMemberPushBtn = self.maintenanceEditMemberPushButton
+        self.maintenanceEditMemberPushBtn: QPushButton = self.maintenanceEditMemberPushButton
         self.maintenanceEditMemberPushBtn.clicked.connect(self.openEditMemberDialog) # Signal
-        self.maintenanceEditMembershipPushBtn = self.maintenanceEditMembershipPushButton
+        self.maintenanceEditMembershipPushBtn: QPushButton = self.maintenanceEditMembershipPushButton
         self.maintenanceEditMembershipPushBtn.clicked.connect(self.openEditMembershipDialog) # Signal
-        self.maintenanceEditGroupPushBtn = self.maintenanceEditGroupPushButton
+        self.maintenanceEditGroupPushBtn: QPushButton = self.maintenanceEditGroupPushButton
         self.maintenanceEditGroupPushBtn.clicked.connect(self.openEditGroupDialog) # Signal
-        self.maintenanceEditPartyPushBtn = self.maintenanceEditPartyPushButton
+        self.maintenanceEditPartyPushBtn: QPushButton = self.maintenanceEditPartyPushButton
         self.maintenanceEditPartyPushBtn.clicked.connect(self.openEditPartyDialog) # Signal
         
-        self.maintenanceRemoveMembershipPB = self.maintenanceRemoveMembershipPushButton
+        self.maintenanceRemoveMembershipPB: QPushButton = self.maintenanceRemoveMembershipPushButton
         self.maintenanceRemoveMembershipPB.clicked.connect(self.openRemoveMembershipDialog)
         
 
-        self.maintenanceTW = self.maintenanceTableWidget
-        self.maintenanceCB = self.maintenanceComboBox
+        self.maintenanceTW: QTableWidget = self.maintenanceTableWidget
+        self.maintenanceTableCB: QComboBox = self.maintenanceComboBox
 
         cbOptionsList = ["Kaikki jäsenet", "Ryhmät jäsenillä", "Seurue ryhmillä"]
 

--- a/desktopApp/tabs/maintenanceTabWidget.py
+++ b/desktopApp/tabs/maintenanceTabWidget.py
@@ -61,6 +61,8 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
 
         self.maintenanceTW: QTableWidget = self.maintenanceTableWidget
         self.maintenanceTableCB: QComboBox = self.maintenanceComboBox
+        
+        self.maintenanceSortCB: QComboBox = self.maintenanceSortComboBox
 
         cbOptionsList = ["Kaikki jäsenet", "Ryhmät jäsenillä", "Seurue ryhmillä"]
 
@@ -120,8 +122,61 @@ class Ui_maintenanceTabWidget(QScrollArea, QWidget):
         else:
             prepareData.prepareTable(databaseOperation1, self.maintenanceTW)
 
-            if tableToShow == "public.ryhma":
-                pass
+    
+    def handleTableOptionChange(self):
+        """
+            Handles the change of the table option combo box and changes
+            the sort options combo box accordingly and populates the table
+        """
+        
+        
+        memberTableOptions = [
+            "Nimi \u2193",
+            "Nimi \u2191",
+            "Osoite \u2193",
+            "Osoite \u2191",
+            "Postinumero \u2193",
+            "Postinumero \u2191",
+            "Postitoimipaikka \u2193",
+            "Postitoimipaikka \u2191",
+            "Tila \u2193",
+            "Tila \u2191"
+        ]
+        
+        groupTableOptions = [
+            "Ryhmän nimi \u2193",
+            "Ryhmän nimi \u2191",
+            "Nimi \u2193",
+            "Nimi \u2191",
+            "Liittynyt \u2193",
+            "Liittynyt \u2191",
+            "Poistunut \u2193",
+            "Poistunut \u2191",
+            "Osuus \u2193",
+            "Osuus \u2191"
+        ]
+        
+        partyTableOptions = [
+            "Seurueen nimi \u2193",
+            "Seurueen nimi \u2191",
+            "Ryhmän nimi \u2193",
+            "Ryhmän nimi \u2191"
+        ]
+        
+        # Check which table is selected and populate the sort options combo box accordingly
+        if self.maintenanceTableCB.currentText() == "Kaikki jäsenet":
+            self.maintenanceSortCB.clear()
+            self.maintenanceSortCB.addItems(memberTableOptions)
+            
+        elif self.maintenanceTableCB.currentText() == "Ryhmät jäsenillä":
+            self.maintenanceSortCB.clear()
+            self.maintenanceSortCB.addItems(groupTableOptions)
+            
+        elif self.maintenanceTableCB.currentText() == "Seurue ryhmillä":
+            self.maintenanceSortCB.clear()
+            self.maintenanceSortCB.addItems(partyTableOptions)
+        
+        self.populateMaintenancePage()
 
     #SIGNALS
     def openSettingsDialog(self):

--- a/desktopApp/ui/maintenanceTab.ui
+++ b/desktopApp/ui/maintenanceTab.ui
@@ -27,8 +27,8 @@
      <rect>
       <x>0</x>
       <y>0</y>
-      <width>939</width>
-      <height>759</height>
+      <width>937</width>
+      <height>757</height>
      </rect>
     </property>
     <widget class="QPushButton" name="maintenanceAddMembershipPushButton">
@@ -290,6 +290,29 @@
      </property>
      <property name="text">
       <string>Poista jäsenyys...</string>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="maintenanceSortComboBox">
+     <property name="geometry">
+      <rect>
+       <x>760</x>
+       <y>50</y>
+       <width>170</width>
+       <height>22</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_4">
+     <property name="geometry">
+      <rect>
+       <x>760</x>
+       <y>30</y>
+       <width>170</width>
+       <height>13</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Lajittele</string>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
In this PR the following items were done:

- [X] Added `QComboBox` widget for displaying the sort options
- [X] Added method that populates the combo box with options based on the selected table view
- [X] Added methods for sorting the tables based on the selected view
- [X] Type hints were added to widgets defined earlier in the tab