### PR TITLE
156 add endpoint for saving shot and its usages

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,8 @@ import seurueRouter from "./routers/seurueRouter";
 import jasenyysRouter from "./routers/jasenyysRouter";
 import apiViewRouter from "./routers/apiViewRouter";
 import optionTablesRouter from "./routers/optionTablesRouter";
-import { errorHandler } from './utils/middleware';  // Import errorHandler
+import createShotUsageRouter from "./routers/createShotUsageRouter";
+import { errorHandler } from "./utils/middleware"; // Import errorHandler
 
 // Initialize the Express application
 const app = express();
@@ -39,6 +40,7 @@ app.use("/api/seurue", seurueRouter);
 app.use("/api/jasenyys", jasenyysRouter);
 app.use("/api/view", apiViewRouter);
 app.use("/api/option-tables", optionTablesRouter);
+app.use("/api/createShotUsage", createShotUsageRouter);
 
 // Centralized error handling
 app.use(errorHandler);

--- a/server/routers/createShotUsageRouter.ts
+++ b/server/routers/createShotUsageRouter.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import { createShotUsage } from "../services/createShotUsageService";
+
+const createShotUsageRouter = express.Router();
+
+// APi endpoint for creating a shot and usages related to it
+createShotUsageRouter.post("/", (async (req, res) => {
+    const shotUsage = await createShotUsage(req.body);
+    res.json(shotUsage);
+}) as express.RequestHandler);
+
+export default createShotUsageRouter;

--- a/server/services/createShotUsageService.ts
+++ b/server/services/createShotUsageService.ts
@@ -1,0 +1,40 @@
+import prisma from "../client";
+import { kaatoInput } from "../zodSchemas/kaatoZod";
+import { kaadonkasittelySchemaOnlyKasittely } from "../zodSchemas/kaadonkasittelyZod";
+
+export const createShotUsage = async (data: unknown) => {
+    // Check that the data is an object
+    if (!data || typeof data !== "object") {
+        throw new Error("Incorrect or missing data");
+    }
+
+    // Check that the data contains the required fields
+    if (!("shot" in data && "usages" in data)) {
+        throw new Error("Body must contain shot and usages fields");
+    }
+
+    // Check that the usages field is an array
+    if (!(data.usages instanceof Array))
+        throw new Error("Usages must be an array");
+
+    // Use zod to validate the data
+    const shot = kaatoInput.parse(data.shot);
+    const usages = data.usages.map((usage) =>
+        kaadonkasittelySchemaOnlyKasittely.parse(usage)
+    );
+
+    // Check that the usages array is not empty and throw an error if it is
+    if (usages.length === 0) throw new Error("No usages provided");
+
+    // Create the shot usage in the database
+    const shotUsage = await prisma.kaato.create({
+        data: {
+            ...shot,
+            kaadon_kasittely: {
+                create: usages,
+            },
+        },
+    });
+
+    return shotUsage;
+};

--- a/server/zodSchemas/kaadonkasittelyZod.ts
+++ b/server/zodSchemas/kaadonkasittelyZod.ts
@@ -16,5 +16,12 @@ const kaadonkasittelySchema = z.object({
     kasittely_maara: z.number().int(),
 });
 
+// Zod schema for validating the shot usage object without the shot usage id
+// and shot id fields
+export const kaadonkasittelySchemaOnlyKasittely = kaadonkasittelySchema.omit({
+    kaadon_kasittely_id: true,
+    kaato_id: true,
+});
+
 // Export the schema so it can be used in other modules
 export default kaadonkasittelySchema;


### PR DESCRIPTION
Added new endpoint to the server for creating a shot and it's usages with only one call to the server.

The the current accepted format for the data in the body of the request is as follows:

```javascript
shot: {
        // jasen_id: <integer>,
        // kaatopaiva: <string as ISO datetime>, (YYYY-MM-DDTHH:mm:ssZ)
        // paikka_teksti: <string>,
        // paikka_koordinaatti: <string>, (optional)
        // ruhopaino: <float>,
        // elaimen_nimi: <string>,
        // sukupuoli: <string>,
        // ikaluokka: <string>,
        // lisatieto: <string>, (optional)
    },
    usages: [
        {
            // kasittelyid: <integer>,
            // kasittely_maara: <integer between 0-100>,
        },
        // Add more usages if needed
    ]
```