### PR TITLE
200 implement pull to refresh feature to mobile

### DIFF
--- a/mobileApp/hooks/useFetch.ts
+++ b/mobileApp/hooks/useFetch.ts
@@ -17,6 +17,8 @@ function useFetch<T>(url: string) {
     const urlCompose = `${BASE_URL}/api/v1/${url}`;
 
     useEffect(() => {
+        // Function to fetch data from the backend
+        // and set the data, error and loading state accordingly
         const fetchGet = async () => {
             try {
                 setLoading(true);
@@ -39,9 +41,20 @@ function useFetch<T>(url: string) {
             }
         };
 
+        // Check if loading is false to prevent infinite loop
+        if (!loading) return;
+
         fetchGet();
-    }, [url]);
-    return { data, error, loading };
+    }, [url, loading]);
+
+    // Function for ScrollView and FlatList
+    // to set the loading state to true
+    // which will trigger the useEffect to fetch the data again
+    const onRefresh = () => {
+        setLoading(true);
+    };
+
+    return { data, error, loading, onRefresh };
 }
 
 export default useFetch;

--- a/mobileApp/src/components/AppBars/FormAppBar.tsx
+++ b/mobileApp/src/components/AppBars/FormAppBar.tsx
@@ -51,7 +51,7 @@ export default function FormAppBar({
                 (item) => item.kasittelyid !== undefined
             );
 
-            path = `createShotUsage`;
+            path = `shot-with-usages`;
 
             payload = {
                 shot,
@@ -71,7 +71,7 @@ export default function FormAppBar({
 
         console.log("Submitting...");
 
-        fetch(`${BASE_URL}/api/${path}`, {
+        fetch(`${BASE_URL}/api/v1/${path}`, {
             method,
             headers: {
                 "Content-Type": "application/json",

--- a/mobileApp/src/screens/GraphScreen/ChartVictoryXL.tsx
+++ b/mobileApp/src/screens/GraphScreen/ChartVictoryXL.tsx
@@ -6,7 +6,6 @@ import {
     LinearGradient,
     useFont,
     vec,
-    Circle,
     Text as SkText,
 } from "@shopify/react-native-skia";
 import type { SharedValue } from "react-native-reanimated";

--- a/mobileApp/src/screens/GroupScreen/index.tsx
+++ b/mobileApp/src/screens/GroupScreen/index.tsx
@@ -1,7 +1,7 @@
 import { View } from "react-native";
 import { MaintenanceTabScreenProps } from "../../NavigationTypes";
 import { Text, ActivityIndicator, useTheme } from "react-native-paper";
-import { ScrollView } from "react-native-gesture-handler";
+import { ScrollView, RefreshControl } from "react-native-gesture-handler";
 import { GroupViewQuery } from "../../types";
 import useFetch from "../../../hooks/useFetch";
 import GroupListItem from "./GroupListItem";
@@ -10,14 +10,14 @@ type Props = MaintenanceTabScreenProps<"Ryhmät">;
 
 // Screen for displaying all groups in Groups tab
 function GroupScreen({ navigation, route }: Props) {
-    const results = useFetch<GroupViewQuery[]>(
+    const { data, loading, error, onRefresh } = useFetch<GroupViewQuery[]>(
         "views/?name=mobiili_ryhma_sivu"
     );
 
     const theme = useTheme();
 
     // Group the groups by party
-    const groupsByParty = results.data?.reduce((acc, group) => {
+    const groupsByParty = data?.reduce((acc, group) => {
         // If the party is not yet in the array, add it
         // Otherwise, add the group to the party's groups
         if (!acc.some((item) => item.party === group.seurue_id)) {
@@ -59,12 +59,12 @@ function GroupScreen({ navigation, route }: Props) {
     });
 
     return (
-        <ScrollView>
-            {results.loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <>{partyContent}</>
-            )}
+        <ScrollView
+            refreshControl={
+                <RefreshControl refreshing={loading} onRefresh={onRefresh} />
+            }
+        >
+            <>{partyContent}</>
         </ScrollView>
     );
 }

--- a/mobileApp/src/screens/GroupShareScreen/index.tsx
+++ b/mobileApp/src/screens/GroupShareScreen/index.tsx
@@ -1,6 +1,6 @@
 import useFetch from "../../../hooks/useFetch";
 import { ActivityIndicator } from "react-native-paper";
-import { FlatList } from "react-native-gesture-handler";
+import { FlatList, RefreshControl } from "react-native-gesture-handler";
 import { ShareTabScreenProps } from "../../NavigationTypes";
 import { ShareViewQuery } from "../../types";
 import GroupShareListItem from "./GroupShareListItem";
@@ -9,24 +9,19 @@ type Props = ShareTabScreenProps<"Ryhmille">;
 
 //Screen for displaying shares meant for groups
 function GroupShareScreen({ navigation, route }: Props) {
-    const { data, loading, error } = useFetch<ShareViewQuery[]>(
+    const { data, loading, error, onRefresh } = useFetch<ShareViewQuery[]>(
         "views/?name=mobiili_ryhmien_jaot&column=kaadon_kasittely.kasittelyid&value=2"
     );
 
     return (
-        <>
-            {loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <FlatList
-                    data={data}
-                    keyExtractor={(item) => item.kaadon_kasittely_id.toString()}
-                    renderItem={({ item }) => (
-                        <GroupShareListItem share={item} />
-                    )}
-                />
-            )}
-        </>
+        <FlatList
+            data={data}
+            keyExtractor={(item) => item.kaadon_kasittely_id.toString()}
+            refreshControl={
+                <RefreshControl refreshing={loading} onRefresh={onRefresh} />
+            }
+            renderItem={({ item }) => <GroupShareListItem share={item} />}
+        />
     );
 }
 

--- a/mobileApp/src/screens/MemberScreen/index.tsx
+++ b/mobileApp/src/screens/MemberScreen/index.tsx
@@ -1,6 +1,6 @@
 import { ActivityIndicator, Text, useTheme } from "react-native-paper";
 import { useState } from "react";
-import { FlatList } from "react-native-gesture-handler";
+import { FlatList, RefreshControl } from "react-native-gesture-handler";
 import { Jasen } from "../../types";
 import MemberListItem from "./MemberListItem";
 import { MaintenanceTabScreenProps } from "../../NavigationTypes";
@@ -18,7 +18,7 @@ type MembersByLetter = {
 
 // Screen for displaying all members in Maintenance tab
 function MemberScreen({ navigation, route }: Props) {
-    const { data, loading, error } = useFetch<Jasen[]>("members");
+    const { data, loading, error, onRefresh } = useFetch<Jasen[]>("members");
     const [scrollValue, setScrollValue] = useState(0);
 
     const theme = useTheme();
@@ -92,23 +92,23 @@ function MemberScreen({ navigation, route }: Props) {
 
     return (
         <>
-            {loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <>
-                    <FlatList //TODO: Add sticky headers? https://reactnative.dev/docs/flatlist#stickyheadersenabled
-                        data={membersByLetter}
-                        keyExtractor={(item) => item.letter}
-                        renderItem={({ item }) => (
-                            <MemberContent
-                                letter={item.letter}
-                                members={item.members}
-                            />
-                        )}
-                        onScroll={onScroll}
+            <FlatList //TODO: Add sticky headers? https://reactnative.dev/docs/flatlist#stickyheadersenabled
+                data={membersByLetter}
+                keyExtractor={(item) => item.letter}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={loading}
+                        onRefresh={onRefresh}
                     />
-                </>
-            )}
+                }
+                renderItem={({ item }) => (
+                    <MemberContent
+                        letter={item.letter}
+                        members={item.members}
+                    />
+                )}
+                onScroll={onScroll}
+            />
             <FloatingNavigationButton
                 scrollValue={scrollValue}
                 type="jäsen"

--- a/mobileApp/src/screens/MemberShareScreen/index.tsx
+++ b/mobileApp/src/screens/MemberShareScreen/index.tsx
@@ -1,6 +1,6 @@
 import useFetch from "../../../hooks/useFetch";
 import { ActivityIndicator } from "react-native-paper";
-import { FlatList } from "react-native-gesture-handler";
+import { FlatList, RefreshControl } from "react-native-gesture-handler";
 import { ShareTabScreenProps } from "../../NavigationTypes";
 import { ShareViewQuery } from "../../types";
 import MemberShareListItem from "./MembershareListItem";
@@ -9,24 +9,19 @@ type Props = ShareTabScreenProps<"Jäsenille">;
 
 //Screen for displaying shares meant for groups
 function MemberShareScreen({ navigation, route }: Props) {
-    const { data, loading, error } = useFetch<ShareViewQuery[]>(
+    const { data, loading, error, onRefresh } = useFetch<ShareViewQuery[]>(
         "views/?name=mobiili_ryhmien_jaot&column=kaadon_kasittely.kasittelyid&value=5"
     );
 
     return (
-        <>
-            {loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <FlatList
-                    data={data}
-                    keyExtractor={(item) => item.kaadon_kasittely_id.toString()}
-                    renderItem={({ item }) => (
-                        <MemberShareListItem share={item} />
-                    )}
-                />
-            )}
-        </>
+        <FlatList
+            data={data}
+            keyExtractor={(item) => item.kaadon_kasittely_id.toString()}
+            refreshControl={
+                <RefreshControl refreshing={loading} onRefresh={onRefresh} />
+            }
+            renderItem={({ item }) => <MemberShareListItem share={item} />}
+        />
     );
 }
 

--- a/mobileApp/src/screens/PartyScreen/index.tsx
+++ b/mobileApp/src/screens/PartyScreen/index.tsx
@@ -1,15 +1,15 @@
 import useFetch from "../../../hooks/useFetch";
 import { PartyViewQuery } from "../../types";
 import { MaintenanceTabScreenProps } from "../../NavigationTypes";
-import { FlatList, ScrollView } from "react-native-gesture-handler";
+import { ScrollView, RefreshControl } from "react-native-gesture-handler";
 import PartyListItem from "./PartyListItem";
-import { Text, ActivityIndicator, useTheme } from "react-native-paper";
+import { Text, useTheme } from "react-native-paper";
 import { View } from "react-native";
 
 type Props = MaintenanceTabScreenProps<"Seurueet">;
 
 function PartyScreen({ navigation, route }: Props) {
-    const { data, loading } = useFetch<PartyViewQuery[]>(
+    const { data, loading, error, onRefresh } = useFetch<PartyViewQuery[]>(
         `views/?name=mobiili_seurue_sivu`
     );
 
@@ -54,12 +54,12 @@ function PartyScreen({ navigation, route }: Props) {
     });
 
     return (
-        <ScrollView>
-            {loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <>{partyContent}</>
-            )}
+        <ScrollView
+            refreshControl={
+                <RefreshControl refreshing={loading} onRefresh={onRefresh} />
+            }
+        >
+            <>{partyContent}</>
         </ScrollView>
     );
 }

--- a/mobileApp/src/screens/ShotScreen/index.tsx
+++ b/mobileApp/src/screens/ShotScreen/index.tsx
@@ -1,7 +1,7 @@
 import { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 import { useState } from "react";
-import { Text, ActivityIndicator } from "react-native-paper";
-import { FlatList } from "react-native-gesture-handler";
+import { Text } from "react-native-paper";
+import { FlatList, RefreshControl } from "react-native-gesture-handler";
 import useFetch from "../../../hooks/useFetch";
 import { BottomTabScreenProps } from "../../NavigationTypes";
 import { ShotViewQuery } from "../../types";
@@ -25,12 +25,8 @@ function ShotScreen({ navigation, route }: Props) {
         setScrollValue(currentScrollPosition);
     };
 
-    const onSwipeDown = () => {
-        console.log("swipe");
-    };
-
     // Fetch all shots from the API
-    const { data, loading, error } = useFetch<ShotViewQuery[]>(
+    const { data, loading, error, onRefresh } = useFetch<ShotViewQuery[]>(
         "views/?name=mobiili_kaato_sivu"
     );
 
@@ -43,26 +39,26 @@ function ShotScreen({ navigation, route }: Props) {
     // TODO: Add error handling
     return (
         <>
-            {loading ? (
-                <ActivityIndicator size={"large"} style={{ paddingTop: 50 }} />
-            ) : (
-                <>
-                    <FlatList
-                        data={data}
-                        keyExtractor={(item) => item.kaato_id.toString()}
-                        renderItem={({ item }) => (
-                            <ShotListItem shot={item} navigation={navigation} />
-                        )}
-                        onScroll={onScroll}
-                        // onGestureEvent={console.log("gesture")}
+            <FlatList
+                data={data}
+                keyExtractor={(item) => item.kaato_id.toString()}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={loading}
+                        onRefresh={onRefresh}
                     />
-                    <FloatingNavigationButton
-                        scrollValue={scrollValue}
-                        type="kaato"
-                        label="Lisää kaato  "
-                    />
-                </>
-            )}
+                }
+                renderItem={({ item }) => (
+                    <ShotListItem shot={item} navigation={navigation} />
+                )}
+                onScroll={onScroll}
+                // onGestureEvent={console.log("gesture")}
+            />
+            <FloatingNavigationButton
+                scrollValue={scrollValue}
+                type="kaato"
+                label="Lisää kaato  "
+            />
         </>
     );
 }


### PR DESCRIPTION
Implemeted the pull to refresh functionality by adding the **onRefesh** function in the **useFetch** custom hook which sets the loading state of the hook to true which triggers the **useEffect** again and reloads the data. It's important to check within the **useEffect** if the loading state is false to prevent infinite loop.

As listed in the issue, all list views were updated to implement the pull-to-refresh feature.