### PR TITLE
201 create a build of the mobile app

### DIFF
--- a/mobileApp/README.md
+++ b/mobileApp/README.md
@@ -20,6 +20,12 @@ export const BASE_URL = 'http://<your-ip-address>:3000';
 
 Replace `<your-ip-address>` with your IP address. You can find your IP address by running the following command in the terminal: `ipconfig` on Windows or `ifconfig` on Mac. You can also find the IP address when running the app in the terminal between the `exp://` and `:19000` in the URL.
 
+## Build
+
+To build the apk-file of the application install the Expo CLI by running the following command: `npm install -g eas-cli`. After the installation you need to login to Expo by running the following command: `eas login`.
+
+To build the app run `eas build -p android --profile preview`. This will build the app in expo's servers and you can download the apk-file from the link that is provided after the build is done. If you're using Mac or Linux, you can also build the app locally by adding the `--local` flag to the command.
+
 ## File structure
 
 The `src` folder contains all the code for the app. The `assets` folder contains all the images and fonts used in the app. The `screen` directory is used to store all the screen views used in the app. For singular components, the `components` directory is used which holds for example navigation and app bar components among others.
@@ -39,7 +45,6 @@ Short description of the modules:
 | utils | Directory for utilities |
 | NavigationTypes.ts | Types for navigation |
 | types.ts | Types for the app |
-
 
 ## Libraries
 

--- a/mobileApp/app.json
+++ b/mobileApp/app.json
@@ -21,10 +21,16 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.eeroleppalehto.mobileApp"
     },
     "web": {
       "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "24c9258b-150c-43b3-97b0-5d26870d4178"
+      }
     }
   }
 }

--- a/mobileApp/eas.json
+++ b/mobileApp/eas.json
@@ -1,0 +1,20 @@
+{
+  "cli": {
+    "version": ">= 5.9.1"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+        "android": {
+          "buildType": "apk"
+        }
+      },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/mobileApp/package-lock.json
+++ b/mobileApp/package-lock.json
@@ -17,7 +17,8 @@
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/native-stack": "^6.9.13",
         "@shopify/react-native-skia": "0.1.196",
-        "expo": "^49.0.0",
+        "expo": "^49.0.6",
+        "expo-splash-screen": "~0.20.5",
         "expo-status-bar": "~1.6.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
@@ -2222,15 +2223,15 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.10.9",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.10.9.tgz",
-      "integrity": "sha512-aK/2ZPC01rD7H4zDiM+GQHorjrOhgo0I+6AGht7RUL3M022TnarlLVc6KJDhVCMeXLaPuerJrsEJm5Hvgl1mNw==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.10.11.tgz",
+      "integrity": "sha512-ehaAOw4SwkJ9uL5z9c3RD4LJpmMDCXZBCWZG4fonUGutks4t/GLoNRcdENkWsf6NSgkdPNgNl8KwphU1p083PQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
         "@expo/config": "~8.1.0",
         "@expo/config-plugins": "~7.2.0",
-        "@expo/dev-server": "0.5.4",
+        "@expo/dev-server": "0.5.5",
         "@expo/devcert": "^1.0.0",
         "@expo/env": "0.0.5",
         "@expo/json-file": "^8.2.37",
@@ -2575,9 +2576,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@expo/dev-server": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.5.4.tgz",
-      "integrity": "sha512-+4CxCWq+lLIiOtO6r1CErU9U4irepBJbXUMzeQ3Vik9FEkuhMwSHHHAxxOB+VmD5IuomubUY3RVMUzEWABIouw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.5.5.tgz",
+      "integrity": "sha512-t0fT8xH1exwYsH5hh7bAt85VF+gXxg24qrbny2rR/iKoPTWFCd2JNQV8pvfLg51hvrywQ3YCBuT3lU1w7aZxFA==",
       "dependencies": {
         "@expo/bunyan": "4.0.0",
         "@expo/metro-config": "~0.10.0",
@@ -2675,9 +2676,9 @@
       }
     },
     "node_modules/@expo/dev-server/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7873,9 +7874,12 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
+      "integrity": "sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -9499,16 +9503,16 @@
       }
     },
     "node_modules/expo": {
-      "version": "49.0.0",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-49.0.0.tgz",
-      "integrity": "sha512-6Z0niKnAx0/amM0MDA8ekYwjDnhgRA0gCYwMnN9v0z0zH1ObBxWio8MzRgFyki3dCxktS8Z6WzuYLfnIkTY22w==",
+      "version": "49.0.6",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-49.0.6.tgz",
+      "integrity": "sha512-prwW1DNTehTdJh2xp+HrEMVrO53WfFNdCC9c2yo3BfsqASGhP8LUePC+RyNgNZzOTL0OsXY7pxkEd0zH1idudA==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.10.9",
+        "@expo/cli": "0.10.11",
         "@expo/config": "8.1.2",
         "@expo/config-plugins": "7.2.5",
         "@expo/vector-icons": "^13.0.0",
-        "babel-preset-expo": "~9.5.0",
+        "babel-preset-expo": "~9.5.1",
         "expo-application": "~5.3.0",
         "expo-asset": "~8.10.1",
         "expo-constants": "~14.4.2",
@@ -9516,7 +9520,7 @@
         "expo-font": "~11.4.0",
         "expo-keep-awake": "~12.3.0",
         "expo-modules-autolinking": "1.5.0",
-        "expo-modules-core": "1.5.4",
+        "expo-modules-core": "1.5.9",
         "fbemitter": "^3.0.0",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3",
@@ -9706,12 +9710,23 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.5.4.tgz",
-      "integrity": "sha512-/oID+SnVYUakb1De3FoT/gBPosPjY+docyHc+M8ZoPsA3LOdlCOkrQG9yw2lWEP2wDNVN6SAa/wcyNeLSIbdAw==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.5.9.tgz",
+      "integrity": "sha512-kQxllZfus7wM0O6X0Ud+SOnbH/kbxtEAQp2gkvDq3P3kqhtafue/H9CPDX04uWc/pypvp9vp/sZ+qvA0alaVuQ==",
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.20.5.tgz",
+      "integrity": "sha512-nTALYdjHpeEA30rdOWSguxn72ctv8WM8ptuUgpfRgsWyn4i6rwYds/rBXisX69XO5fg+XjHAQqijGx/b28+3tg==",
+      "dependencies": {
+        "@expo/prebuild-config": "6.2.6"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {
@@ -13368,9 +13383,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -14182,9 +14197,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -14200,7 +14215,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/mobileApp/package.json
+++ b/mobileApp/package.json
@@ -4,12 +4,13 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.11",
+    "@react-native-community/slider": "4.4.2",
     "@react-navigation/drawer": "^6.6.3",
     "@react-navigation/elements": "^1.3.18",
     "@react-navigation/material-bottom-tabs": "^6.2.16",
@@ -17,7 +18,8 @@
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",
     "@shopify/react-native-skia": "0.1.196",
-    "expo": "^49.0.0",
+    "expo": "^49.0.6",
+    "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
@@ -30,8 +32,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-tab-view": "^3.5.2",
-    "victory-native": "40.0.2",
-    "@react-native-community/slider": "4.4.2"
+    "victory-native": "40.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Tested building the **apk** of the application by using the **eas** build service To use this service I needed to install `eas-cli` tools
on my machine and log into **Expo**. Before starting the build, `eas.json` needed to be initialized and configured.

Ran into build errors during the build originating from `expo-spalsh-screen` which was fixed when upgrading **Expo** SDK to 49.0.6 from 49.0.0.

Added documentation into mobile applications README.md file for building the apk on your own.