### PR TITLE
203 make a docker of the server application

### DIFF
--- a/postgresDocker/README.md
+++ b/postgresDocker/README.md
@@ -17,6 +17,8 @@ Ensiksi tulee luoda postges Docker-image, jolla on suomalaiset merkistöt käyt�
 docker build -t postgres-14-fi:latest .
 ```
 
+Tämän lisäksi tulee luoda Docker-image node palvelimelle, joka käyttää luotua postgres-tietokantaa. Tämän luomiseksi seuraa server-kansion README.md tiedostossa olevia ohjeita Build-osiossa.
+
 Seuraava komento rakentaa docker kompoosin, joka sisältää sekä juuri luodun posgres-tietokannan että pgAdminin web-palvelimen. Luodakseen kompoosin, tulee kansiossa olla `.env`-tiedosto, jossa on määritelty seuraavat muuttujat
 
 * POSTGRES_USER
@@ -30,6 +32,8 @@ Komento myös ajaa `init`-kansiossa olevan SQL-skriptin, joka luo sovelluksen ti
 ```docker
 docker-compose up -d
 ```
+
+Jos olet tehnyt muutoksia
 
 ## pgAdmin
 

--- a/postgresDocker/compose.yaml
+++ b/postgresDocker/compose.yaml
@@ -33,7 +33,7 @@ services:
     environment:
      - DATABASE_URL=postgresql://application:Q2werty@postgres:5432/dev_metsastys?schema=public
      - PORT=8080
-    command: npm start
+    command: node index.js
     ports:
       - "8080:8080"
     restart: always

--- a/postgresDocker/compose.yaml
+++ b/postgresDocker/compose.yaml
@@ -22,3 +22,22 @@ services:
     ports:
       - "5050:80"
     restart: always
+
+  node-server:
+    container_name: node-server
+    image: node-server:latest
+    build: ../server
+    working_dir: /home/node/app
+    env_file:
+      - .env
+    environment:
+     - DATABASE_URL=postgresql://application:Q2werty@postgres:5432/dev_metsastys?schema=public
+     - PORT=8080
+    command: npm start
+    ports:
+      - "8080:8080"
+    restart: always
+    depends_on:
+      - postgres
+    # volumes:
+    #   - ./node-server:/home/node/app

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,16 @@
+# FROM node:18.18.0-alpine3.17
+# RUN mkdir -p /home/node/app
+# WORKDIR /home/node/app
+# COPY package*.json prisma/ ./
+# RUN npm install --omit=dev
+# COPY build/ .
+# EXPOSE 8080
+# CMD [ "npm", "start"]
+
+FROM node:18.18.0-alpine3.17
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+COPY build/ .
+RUN npm install --omit=dev
+EXPOSE 8080
+CMD [ "npm", "start"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,16 +1,9 @@
-# FROM node:18.18.0-alpine3.17
-# RUN mkdir -p /home/node/app
-# WORKDIR /home/node/app
-# COPY package*.json prisma/ ./
-# RUN npm install --omit=dev
-# COPY build/ .
-# EXPOSE 8080
-# CMD [ "npm", "start"]
-
 FROM node:18.18.0-alpine3.17
 RUN mkdir -p /home/node/app
 WORKDIR /home/node/app
 COPY build/ .
+ENV DATABASE_URL="postgresql://application:Q2werty@localhost:5432/dev_metsastys?schema=public"
+ENV PORT=3000
 RUN npm install --omit=dev
-EXPOSE 8080
+EXPOSE 3000
 CMD [ "node", "index.js"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /home/node/app
 COPY build/ .
 RUN npm install --omit=dev
 EXPOSE 8080
-CMD [ "npm", "start"]
+CMD [ "node", "index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,7 @@ To get this project up and running on your local machine, follow these steps:
   * `<database>` with the name of the database.
   * `<schema>` with the name of the schema.
 
+* You can specify the port for the server by adding `PORT=<port>` to the .env file. If you don't specify the port, the server will use default port 3000.
 * Once previous steps have been done, run the following command to install the dependencies for the project `npm install`
 
 ## Getting started
@@ -63,3 +64,13 @@ Here is a list of the most important libraries used in the server:
 | Jest | JavaScript Testing Framework | [Documentation](https://jestjs.io/docs/getting-started) |
 | Supertest | HTTP assertions for Jest | [Documentation](https://github.com/ladjs/supertest#readme) |
 | express-async-errors | Async/await error handling for Express | [Documentation](https://github.com/davidbanham/express-async-errors#readme) |
+
+## Build
+
+To build the server, run the following command: `npm run build`. This will compile the TypeScript files to JavaScript files and put them in the build folder. It will also copy the prisma folder, package.json, package-lock.json and .env files to the build folder.
+
+### Docker Image
+
+To build a docker image for the server, run the following command: `docker build -t node-server .`. This will build a docker image with the name node-server. If you're planning to use the docker compose in postgresDocker folder, you need to replace the DATABASE_URL in the .env file to match the docker compose file.
+
+Optionally to run the docker image, run the following command: `docker run -p <port-number>:<port-number> node-server`. This will run the docker image on port. This is not needed if you're planning to use the docker compose in postgresDocker folder.

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@
 import express from "express";
 import cors from "cors";
 import "express-async-errors";
+import "dotenv/config";
 import jasenRouter from "./routers/v1/membersRouter";
 import kaatoRouter from "./routers/v1/shotsRouter";
 import jakoryhmaRouter from "./routers/v1/groupsRouter";
@@ -50,7 +51,7 @@ app.use("/api/v1/member-shares", jakotapahtumaJasenRouter);
 app.use(errorHandler);
 
 // Set the port
-const PORT = 3000;
+const PORT = process.env.PORT ? process.env.PORT : 3000;
 
 // Start the Express server
 app.listen(PORT, () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^5.2.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "uuid": "^9.0.1",
@@ -2776,6 +2777,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dynamic-dedupe": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && cp -r prisma package.json package-lock.json .env build",
     "dev": "ts-node-dev index.ts",
     "lint": "eslint --ext .ts .",
-    "start": "node index.js"
+    "start": "ts-node index.ts"
   },
   "author": "",
   "license": "ISC",

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@prisma/client": "^5.2.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "uuid": "^9.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && cp -r prisma package.json package-lock.json .env build",
     "dev": "ts-node-dev index.ts",
     "lint": "eslint --ext .ts .",
-    "start": "ts-node index.ts"
+    "start": "node index.js"
   },
   "author": "",
   "license": "ISC",

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "tsc": "tsc",
+    "build": "tsc && cp -r prisma package.json package-lock.json .env build",
     "dev": "ts-node-dev index.ts",
     "lint": "eslint --ext .ts .",
     "start": "ts-node index.ts"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -55,7 +55,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./build/",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./build/",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
In this PR following issues were done:

- [x] Add `dotenv` library to allow passing environment variables to server which can be passed when running docker containers 
- [x] Configure building server's TypeScript to JavaScript
- [x] Make Docker image based on the built JS
- [x] Add the server's docker image to the docker compose in **postgresDocker** directory
- [x] Added documentation for running these on your own machine